### PR TITLE
Feature: #52 닉네임 변경, 로그아웃 기능 추가

### DIFF
--- a/data/src/main/java/com/gta/data/di/NicknameModule.kt
+++ b/data/src/main/java/com/gta/data/di/NicknameModule.kt
@@ -1,0 +1,20 @@
+package com.gta.data.di
+
+import com.gta.data.repository.NicknameRepositoryImpl
+import com.gta.data.source.NicknameDataSource
+import com.gta.domain.repository.NicknameRepository
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object NicknameModule {
+
+    @Singleton
+    @Provides
+    fun provideNicknameRepository(dataSource: NicknameDataSource): NicknameRepository =
+        NicknameRepositoryImpl(dataSource)
+}

--- a/data/src/main/java/com/gta/data/model/UserInfo.kt
+++ b/data/src/main/java/com/gta/data/model/UserInfo.kt
@@ -6,7 +6,7 @@ import com.gta.domain.model.UserProfile
 data class UserInfo(
     val chatId: Long = 0L,
     val nickname: String = "이동훈",
-    val icon: String = "none",
+    val icon: String = "",
     val temperature: Float = 36.5f,
     val license: DrivingLicense? = null,
     val rentedCar: Long? = null,

--- a/data/src/main/java/com/gta/data/repository/NicknameRepositoryImpl.kt
+++ b/data/src/main/java/com/gta/data/repository/NicknameRepositoryImpl.kt
@@ -1,0 +1,32 @@
+package com.gta.data.repository
+
+import com.gta.data.source.NicknameDataSource
+import com.gta.domain.model.NicknameState
+import com.gta.domain.repository.NicknameRepository
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import javax.inject.Inject
+
+class NicknameRepositoryImpl @Inject constructor(
+    private val dataSource: NicknameDataSource
+) : NicknameRepository {
+    override fun checkNicknameState(nickname: String): NicknameState =
+        when {
+            nickname.length < MIN_LENGTH -> NicknameState.SHORT_LENGTH
+            SYMBOL_REGEX.containsMatchIn(nickname) -> NicknameState.CONTAIN_SYMBOL
+            else -> NicknameState.GREAT
+        }
+
+    override fun updateNickname(uid: String, nickname: String): Flow<Boolean> = callbackFlow {
+        dataSource.updateNickname(uid, nickname).addOnCompleteListener {
+            trySend(it.isSuccessful)
+        }
+        awaitClose()
+    }
+
+    companion object {
+        private const val MIN_LENGTH = 2
+        private val SYMBOL_REGEX = "[^ㄱ-ㅎㅏ-ㅣ가-힣\\w]+".toRegex()
+    }
+}

--- a/data/src/main/java/com/gta/data/source/NicknameDataSource.kt
+++ b/data/src/main/java/com/gta/data/source/NicknameDataSource.kt
@@ -1,0 +1,12 @@
+package com.gta.data.source
+
+import com.google.android.gms.tasks.Task
+import com.google.firebase.firestore.FirebaseFirestore
+import javax.inject.Inject
+
+class NicknameDataSource @Inject constructor(
+    private val fireStore: FirebaseFirestore
+) {
+    fun updateNickname(uid: String, nickname: String): Task<Void> =
+        fireStore.collection("users").document(uid).update("nickname", nickname)
+}

--- a/domain/src/main/java/com/gta/domain/model/NicknameState.kt
+++ b/domain/src/main/java/com/gta/domain/model/NicknameState.kt
@@ -1,0 +1,8 @@
+package com.gta.domain.model
+
+enum class NicknameState {
+    IDLE,
+    GREAT,
+    SHORT_LENGTH,
+    CONTAIN_SYMBOL
+}

--- a/domain/src/main/java/com/gta/domain/repository/NicknameRepository.kt
+++ b/domain/src/main/java/com/gta/domain/repository/NicknameRepository.kt
@@ -1,0 +1,9 @@
+package com.gta.domain.repository
+
+import com.gta.domain.model.NicknameState
+import kotlinx.coroutines.flow.Flow
+
+interface NicknameRepository {
+    fun checkNicknameState(nickname: String): NicknameState
+    fun updateNickname(uid: String, nickname: String): Flow<Boolean>
+}

--- a/domain/src/main/java/com/gta/domain/usecase/nickname/CheckNicknameStateUseCase.kt
+++ b/domain/src/main/java/com/gta/domain/usecase/nickname/CheckNicknameStateUseCase.kt
@@ -1,0 +1,12 @@
+package com.gta.domain.usecase.nickname
+
+import com.gta.domain.model.NicknameState
+import com.gta.domain.repository.NicknameRepository
+import javax.inject.Inject
+
+class CheckNicknameStateUseCase @Inject constructor(
+    private val repository: NicknameRepository
+) {
+    operator fun invoke(nickname: String): NicknameState =
+        repository.checkNicknameState(nickname)
+}

--- a/domain/src/main/java/com/gta/domain/usecase/nickname/UpdateNicknameUseCase.kt
+++ b/domain/src/main/java/com/gta/domain/usecase/nickname/UpdateNicknameUseCase.kt
@@ -1,0 +1,12 @@
+package com.gta.domain.usecase.nickname
+
+import com.gta.domain.repository.NicknameRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class UpdateNicknameUseCase @Inject constructor(
+    private val repository: NicknameRepository
+) {
+    operator fun invoke(uid: String, nickname: String): Flow<Boolean> =
+        repository.updateNickname(uid, nickname)
+}

--- a/domain/src/main/java/com/gta/domain/usecase/user/GetUserProfileUseCase.kt
+++ b/domain/src/main/java/com/gta/domain/usecase/user/GetUserProfileUseCase.kt
@@ -8,5 +8,5 @@ import javax.inject.Inject
 class GetUserProfileUseCase @Inject constructor(
     private val repository: UserRepository
 ) {
-    operator fun invoke(uid: String): Flow<UserProfile?> = repository.getUserProfile(uid)
+    operator fun invoke(uid: String): Flow<UserProfile> = repository.getUserProfile(uid)
 }

--- a/presentation/src/main/java/com/gta/presentation/ui/MainActivity.kt
+++ b/presentation/src/main/java/com/gta/presentation/ui/MainActivity.kt
@@ -1,5 +1,6 @@
 package com.gta.presentation.ui
 
+import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import androidx.navigation.fragment.NavHostFragment
@@ -7,15 +8,29 @@ import androidx.navigation.ui.AppBarConfiguration
 import androidx.navigation.ui.navigateUp
 import androidx.navigation.ui.setupActionBarWithNavController
 import androidx.navigation.ui.setupWithNavController
+import com.google.firebase.auth.FirebaseAuth
 import com.gta.presentation.R
 import com.gta.presentation.databinding.ActivityMainBinding
 import com.gta.presentation.secret.NAVER_MAP_CLIENT_ID
 import com.gta.presentation.ui.base.BaseActivity
+import com.gta.presentation.ui.login.LoginActivity
 import com.naver.maps.map.NaverMapSdk
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class MainActivity : BaseActivity<ActivityMainBinding>(ActivityMainBinding::inflate) {
+
+    @Inject
+    lateinit var auth: FirebaseAuth
+    private val authStateListener by lazy {
+        FirebaseAuth.AuthStateListener {
+            if (it.currentUser == null) {
+                startLoginActivity()
+            }
+        }
+    }
+
     private val navHostFragment by lazy { supportFragmentManager.findFragmentById(R.id.fcv_main) as NavHostFragment }
     private val navController by lazy { navHostFragment.navController }
     private val appBarConfiguration = AppBarConfiguration(setOf(R.id.mapFragment, R.id.chattingFragment, R.id.myPageFragment))
@@ -29,6 +44,7 @@ class MainActivity : BaseActivity<ActivityMainBinding>(ActivityMainBinding::infl
 
         setupWithNaverMaps()
         setupActionBarWithNavController(navController, appBarConfiguration)
+        auth.addAuthStateListener(authStateListener)
     }
 
     private fun setupWithBottomNavigation() {
@@ -62,7 +78,18 @@ class MainActivity : BaseActivity<ActivityMainBinding>(ActivityMainBinding::infl
         binding.bnvMain.visibility = View.GONE
     }
 
+    private fun startLoginActivity() {
+        val intent = Intent(this, LoginActivity::class.java)
+        startActivity(intent)
+        finish()
+    }
+
     override fun onSupportNavigateUp(): Boolean {
         return navController.navigateUp(appBarConfiguration) || super.onSupportNavigateUp()
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        auth.removeAuthStateListener(authStateListener)
     }
 }

--- a/presentation/src/main/java/com/gta/presentation/ui/login/LoginViewModel.kt
+++ b/presentation/src/main/java/com/gta/presentation/ui/login/LoginViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.GoogleAuthProvider
 import com.gta.domain.usecase.login.CheckCurrentUserUseCase
+import com.gta.presentation.util.FirebaseUtil
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -35,9 +36,10 @@ class LoginViewModel @Inject constructor(
     }
 
     fun checkCurrentUser() {
-        val uid = auth.currentUser?.uid ?: return
+        val user = auth.currentUser ?: return
+        FirebaseUtil.setUid(user)
         viewModelScope.launch {
-            _loginEvent.emit(useCase(uid).first())
+            _loginEvent.emit(useCase(FirebaseUtil.uid).first())
         }
     }
 }

--- a/presentation/src/main/java/com/gta/presentation/ui/mypage/MyPageFragment.kt
+++ b/presentation/src/main/java/com/gta/presentation/ui/mypage/MyPageFragment.kt
@@ -35,8 +35,15 @@ class MyPageFragment : BaseFragment<FragmentMypageBinding>(
         super.onViewCreated(view, savedInstanceState)
         binding.vm = viewModel
         initCollector()
+        initListener()
+    }
+
+    private fun initListener() {
         binding.ivMypageEditThumb.setOnClickListener {
             updateThumbnail()
+        }
+        binding.btnMypageSignOut.setOnClickListener {
+            viewModel.signOut()
         }
     }
 

--- a/presentation/src/main/java/com/gta/presentation/ui/mypage/MyPageFragment.kt
+++ b/presentation/src/main/java/com/gta/presentation/ui/mypage/MyPageFragment.kt
@@ -10,6 +10,7 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
+import androidx.navigation.fragment.findNavController
 import com.gta.presentation.R
 import com.gta.presentation.databinding.FragmentMypageBinding
 import com.gta.presentation.ui.base.BaseFragment
@@ -42,6 +43,9 @@ class MyPageFragment : BaseFragment<FragmentMypageBinding>(
         binding.ivMypageEditThumb.setOnClickListener {
             updateThumbnail()
         }
+        binding.ivMypageEditNickname.setOnClickListener {
+            viewModel.navigateNicknameEdit()
+        }
         binding.btnMypageSignOut.setOnClickListener {
             viewModel.signOut()
         }
@@ -52,6 +56,15 @@ class MyPageFragment : BaseFragment<FragmentMypageBinding>(
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.thumbnailUpdateEvent.collectLatest { uri ->
                     viewModel.changeThumbnail(uri)
+                }
+            }
+        }
+        lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.nicknameEditEvent.collectLatest { thumb ->
+                    findNavController().navigate(
+                        MyPageFragmentDirections.actionMyPageFragmentToNicknameFragment(thumb)
+                    )
                 }
             }
         }

--- a/presentation/src/main/java/com/gta/presentation/ui/mypage/MyPageViewModel.kt
+++ b/presentation/src/main/java/com/gta/presentation/ui/mypage/MyPageViewModel.kt
@@ -7,6 +7,7 @@ import com.gta.domain.model.UserProfile
 import com.gta.domain.usecase.mypage.DeleteThumbnailUseCase
 import com.gta.domain.usecase.mypage.SetThumbnailUseCase
 import com.gta.domain.usecase.user.GetUserProfileUseCase
+import com.gta.presentation.util.FirebaseUtil
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -33,14 +34,11 @@ class MyPageViewModel @Inject constructor(
     private val _nicknameEditEvent = MutableSharedFlow<String>()
     val nicknameEditEvent: SharedFlow<String> get() = _nicknameEditEvent
 
-    private val uid = auth.currentUser?.uid
-
     init {
         getUserProfile()
     }
 
     fun changeThumbnail(uri: String?) {
-        uri ?: return
         val previousImage = userProfile.value.image ?: ""
         viewModelScope.launch {
             if (previousImage.isNotEmpty()) {
@@ -51,16 +49,14 @@ class MyPageViewModel @Inject constructor(
     }
 
     private fun getUserProfile() {
-        uid ?: return
         viewModelScope.launch {
-            _userProfile.emit(getUserProfileUseCase(uid).first())
+            _userProfile.emit(getUserProfileUseCase(FirebaseUtil.uid).first())
         }
     }
 
     fun updateThumbnail(uri: String) {
-        uid ?: return
         viewModelScope.launch {
-            _thumbnailUpdateEvent.emit(setThumbnailUseCase(uid, uri).first())
+            _thumbnailUpdateEvent.emit(setThumbnailUseCase(FirebaseUtil.uid, uri).first())
         }
     }
 

--- a/presentation/src/main/java/com/gta/presentation/ui/mypage/MyPageViewModel.kt
+++ b/presentation/src/main/java/com/gta/presentation/ui/mypage/MyPageViewModel.kt
@@ -38,9 +38,9 @@ class MyPageViewModel @Inject constructor(
 
     fun changeThumbnail(uri: String?) {
         uri ?: return
-        val previousImage = userProfile.value?.image
+        val previousImage = userProfile.value?.image ?: ""
         viewModelScope.launch {
-            if (previousImage != null) {
+            if (previousImage.isNotEmpty()) {
                 deleteThumbnailUseCase(previousImage).first()
             }
             _userProfile.emit(userProfile.value?.copy(image = uri))

--- a/presentation/src/main/java/com/gta/presentation/ui/mypage/MyPageViewModel.kt
+++ b/presentation/src/main/java/com/gta/presentation/ui/mypage/MyPageViewModel.kt
@@ -24,8 +24,8 @@ class MyPageViewModel @Inject constructor(
     private val deleteThumbnailUseCase: DeleteThumbnailUseCase
 ) : ViewModel() {
 
-    private val _userProfile = MutableStateFlow<UserProfile?>(null)
-    val userProfile: StateFlow<UserProfile?> get() = _userProfile
+    private val _userProfile = MutableStateFlow(UserProfile())
+    val userProfile: StateFlow<UserProfile> get() = _userProfile
 
     private val _thumbnailUpdateEvent = MutableSharedFlow<String?>()
     val thumbnailUpdateEvent: SharedFlow<String?> get() = _thumbnailUpdateEvent
@@ -41,12 +41,12 @@ class MyPageViewModel @Inject constructor(
 
     fun changeThumbnail(uri: String?) {
         uri ?: return
-        val previousImage = userProfile.value?.image ?: ""
+        val previousImage = userProfile.value.image ?: ""
         viewModelScope.launch {
             if (previousImage.isNotEmpty()) {
                 deleteThumbnailUseCase(previousImage).first()
             }
-            _userProfile.emit(userProfile.value?.copy(image = uri))
+            _userProfile.emit(userProfile.value.copy(image = uri))
         }
     }
 
@@ -66,7 +66,7 @@ class MyPageViewModel @Inject constructor(
 
     fun navigateNicknameEdit() {
         viewModelScope.launch {
-            _nicknameEditEvent.emit(userProfile.value?.image ?: "")
+            _nicknameEditEvent.emit(userProfile.value.image ?: "")
         }
     }
 

--- a/presentation/src/main/java/com/gta/presentation/ui/mypage/MyPageViewModel.kt
+++ b/presentation/src/main/java/com/gta/presentation/ui/mypage/MyPageViewModel.kt
@@ -18,7 +18,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class MyPageViewModel @Inject constructor(
-    auth: FirebaseAuth,
+    private val auth: FirebaseAuth,
     private val getUserProfileUseCase: GetUserProfileUseCase,
     private val setThumbnailUseCase: SetThumbnailUseCase,
     private val deleteThumbnailUseCase: DeleteThumbnailUseCase
@@ -59,5 +59,9 @@ class MyPageViewModel @Inject constructor(
         viewModelScope.launch {
             _thumbnailUpdateEvent.emit(setThumbnailUseCase(uid, uri).first())
         }
+    }
+
+    fun signOut() {
+        auth.signOut()
     }
 }

--- a/presentation/src/main/java/com/gta/presentation/ui/mypage/MyPageViewModel.kt
+++ b/presentation/src/main/java/com/gta/presentation/ui/mypage/MyPageViewModel.kt
@@ -30,6 +30,9 @@ class MyPageViewModel @Inject constructor(
     private val _thumbnailUpdateEvent = MutableSharedFlow<String?>()
     val thumbnailUpdateEvent: SharedFlow<String?> get() = _thumbnailUpdateEvent
 
+    private val _nicknameEditEvent = MutableSharedFlow<String>()
+    val nicknameEditEvent: SharedFlow<String> get() = _nicknameEditEvent
+
     private val uid = auth.currentUser?.uid
 
     init {
@@ -58,6 +61,12 @@ class MyPageViewModel @Inject constructor(
         uid ?: return
         viewModelScope.launch {
             _thumbnailUpdateEvent.emit(setThumbnailUseCase(uid, uri).first())
+        }
+    }
+
+    fun navigateNicknameEdit() {
+        viewModelScope.launch {
+            _nicknameEditEvent.emit(userProfile.value?.image ?: "")
         }
     }
 

--- a/presentation/src/main/java/com/gta/presentation/ui/nickname/NicknameFragment.kt
+++ b/presentation/src/main/java/com/gta/presentation/ui/nickname/NicknameFragment.kt
@@ -1,0 +1,63 @@
+package com.gta.presentation.ui.nickname
+
+import android.os.Bundle
+import android.view.View
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import androidx.navigation.fragment.findNavController
+import com.gta.domain.model.NicknameState
+import com.gta.presentation.R
+import com.gta.presentation.databinding.FragmentNicknameBinding
+import com.gta.presentation.ui.base.BaseFragment
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+
+@AndroidEntryPoint
+class NicknameFragment : BaseFragment<FragmentNicknameBinding>(
+    R.layout.fragment_nickname
+) {
+
+    private val viewModel: NicknameViewModel by viewModels()
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        binding.vm = viewModel
+        initCollector()
+    }
+
+    private fun initCollector() {
+        lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.nicknameState.collectLatest { state ->
+                    handleNicknameState(state)
+                }
+            }
+        }
+        lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.nicknameChangeEvent.collectLatest { state ->
+                    if (state) {
+                        findNavController().navigate(R.id.action_nicknameFragment_to_myPageFragment)
+                    }
+                }
+            }
+        }
+    }
+
+    private fun handleNicknameState(state: NicknameState) {
+        when (state) {
+            NicknameState.IDLE, NicknameState.GREAT -> {
+                binding.tlNicknameInput.helperText = getString(R.string.nickname_condition)
+            }
+            NicknameState.SHORT_LENGTH -> {
+                binding.tlNicknameInput.error = getString(R.string.nickname_error_min_length)
+            }
+            NicknameState.CONTAIN_SYMBOL -> {
+                binding.tlNicknameInput.error = getString(R.string.nickname_error_symbols)
+            }
+        }
+    }
+}

--- a/presentation/src/main/java/com/gta/presentation/ui/nickname/NicknameFragment.kt
+++ b/presentation/src/main/java/com/gta/presentation/ui/nickname/NicknameFragment.kt
@@ -10,6 +10,7 @@ import androidx.navigation.fragment.findNavController
 import com.gta.domain.model.NicknameState
 import com.gta.presentation.R
 import com.gta.presentation.databinding.FragmentNicknameBinding
+import com.gta.presentation.ui.MainActivity
 import com.gta.presentation.ui.base.BaseFragment
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
@@ -24,6 +25,7 @@ class NicknameFragment : BaseFragment<FragmentNicknameBinding>(
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        (requireActivity() as MainActivity).supportActionBar?.title = getString(R.string.nickname_toolbar)
         binding.vm = viewModel
         initCollector()
     }

--- a/presentation/src/main/java/com/gta/presentation/ui/nickname/NicknameViewModel.kt
+++ b/presentation/src/main/java/com/gta/presentation/ui/nickname/NicknameViewModel.kt
@@ -3,10 +3,10 @@ package com.gta.presentation.ui.nickname
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.google.firebase.auth.FirebaseAuth
 import com.gta.domain.model.NicknameState
 import com.gta.domain.usecase.nickname.CheckNicknameStateUseCase
 import com.gta.domain.usecase.nickname.UpdateNicknameUseCase
+import com.gta.presentation.util.FirebaseUtil
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -18,7 +18,6 @@ import javax.inject.Inject
 
 @HiltViewModel
 class NicknameViewModel @Inject constructor(
-    auth: FirebaseAuth,
     args: SavedStateHandle,
     private val checkNicknameStateUseCase: CheckNicknameStateUseCase,
     private val updateNicknameUseCase: UpdateNicknameUseCase
@@ -34,8 +33,6 @@ class NicknameViewModel @Inject constructor(
     private val _nicknameChangeEvent = MutableSharedFlow<Boolean>()
     val nicknameChangeEvent: SharedFlow<Boolean> get() = _nicknameChangeEvent
 
-    private val uid = auth.currentUser?.uid
-
     fun checkNicknameState(nickname: String) {
         viewModelScope.launch {
             _nicknameState.emit(checkNicknameStateUseCase(nickname))
@@ -43,10 +40,9 @@ class NicknameViewModel @Inject constructor(
     }
 
     fun updateNickname() {
-        uid ?: return
         if (nicknameState.value == NicknameState.GREAT) {
             viewModelScope.launch {
-                _nicknameChangeEvent.emit(updateNicknameUseCase(uid, nickname.value).first())
+                _nicknameChangeEvent.emit(updateNicknameUseCase(FirebaseUtil.uid, nickname.value).first())
             }
         }
     }

--- a/presentation/src/main/java/com/gta/presentation/ui/nickname/NicknameViewModel.kt
+++ b/presentation/src/main/java/com/gta/presentation/ui/nickname/NicknameViewModel.kt
@@ -1,0 +1,53 @@
+package com.gta.presentation.ui.nickname
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.google.firebase.auth.FirebaseAuth
+import com.gta.domain.model.NicknameState
+import com.gta.domain.usecase.nickname.CheckNicknameStateUseCase
+import com.gta.domain.usecase.nickname.UpdateNicknameUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class NicknameViewModel @Inject constructor(
+    auth: FirebaseAuth,
+    args: SavedStateHandle,
+    private val checkNicknameStateUseCase: CheckNicknameStateUseCase,
+    private val updateNicknameUseCase: UpdateNicknameUseCase
+) : ViewModel() {
+
+    val thumb: StateFlow<String?> = MutableStateFlow(args.get<String>("thumb"))
+
+    val nickname = MutableStateFlow("")
+
+    private val _nicknameState = MutableStateFlow(NicknameState.IDLE)
+    val nicknameState: StateFlow<NicknameState> get() = _nicknameState
+
+    private val _nicknameChangeEvent = MutableSharedFlow<Boolean>()
+    val nicknameChangeEvent: SharedFlow<Boolean> get() = _nicknameChangeEvent
+
+    private val uid = auth.currentUser?.uid
+
+    fun checkNicknameState(nickname: String) {
+        viewModelScope.launch {
+            _nicknameState.emit(checkNicknameStateUseCase(nickname))
+        }
+    }
+
+    fun updateNickname() {
+        uid ?: return
+        if (nicknameState.value == NicknameState.GREAT) {
+            viewModelScope.launch {
+                _nicknameChangeEvent.emit(updateNicknameUseCase(uid, nickname.value).first())
+            }
+        }
+    }
+}

--- a/presentation/src/main/java/com/gta/presentation/util/FirebaseUtil.kt
+++ b/presentation/src/main/java/com/gta/presentation/util/FirebaseUtil.kt
@@ -1,0 +1,12 @@
+package com.gta.presentation.util
+
+import com.google.firebase.auth.FirebaseUser
+
+object FirebaseUtil {
+    var uid = ""
+        private set
+
+    fun setUid(firebaseUser: FirebaseUser) {
+        uid = firebaseUser.uid
+    }
+}

--- a/presentation/src/main/res/layout/fragment_nickname.xml
+++ b/presentation/src/main/res/layout/fragment_nickname.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+        <import type="com.gta.domain.model.NicknameState" />
+        <variable
+            name="vm"
+            type="com.gta.presentation.ui.nickname.NicknameViewModel" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <com.google.android.material.imageview.ShapeableImageView
+            android:id="@+id/iv_nickname_thumb"
+            android:layout_width="80dp"
+            android:layout_height="80dp"
+            android:layout_marginTop="@dimen/padding_extra_large"
+            android:scaleType="centerCrop"
+            app:image_uri="@{vm.thumb}"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.App.CornerSize50Percent"
+            tools:srcCompat="@tools:sample/avatars" />
+
+        <TextView
+            android:id="@+id/tv_nickname_input"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/padding_extra_large"
+            android:text="@string/nickname_input_text"
+            android:textColor="@color/black"
+            android:textSize="@dimen/font_label_large"
+            app:layout_constraintStart_toStartOf="@+id/tl_nickname_input"
+            app:layout_constraintTop_toBottomOf="@+id/iv_nickname_thumb" />
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/tl_nickname_input"
+            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.Dense"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="@dimen/padding_medium"
+            android:layout_marginTop="@dimen/padding_small"
+            app:boxStrokeColor="?attr/colorPrimary"
+            app:boxStrokeErrorColor="@android:color/holo_red_dark"
+            app:errorEnabled="true"
+            app:errorIconDrawable="@null"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_nickname_input">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/et_nickname_input"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:maxLength="10"
+                android:maxLines="1"
+                android:text="@={vm.nickname}"
+                android:textSize="@dimen/font_body_medium"
+                android:afterTextChanged="@{(e) -> vm.checkNicknameState(String.valueOf(e))}"
+                tools:ignore="SpeakableTextPresentCheck" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/button"
+            style="@style/Theme.UCMC.BottomButton"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:text="@string/nickname_btn_apply"
+            android:enabled="@{vm.nicknameState == NicknameState.GREAT}"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/presentation/src/main/res/layout/fragment_nickname.xml
+++ b/presentation/src/main/res/layout/fragment_nickname.xml
@@ -21,9 +21,12 @@
             android:layout_marginTop="@dimen/padding_extra_large"
             android:scaleType="centerCrop"
             app:image_uri="@{vm.thumb}"
+            app:layout_constraintBottom_toTopOf="@id/tv_nickname_input"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_bias="0.0"
+            app:layout_constraintVertical_chainStyle="packed"
             app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.App.CornerSize50Percent"
             tools:srcCompat="@tools:sample/avatars" />
 
@@ -35,6 +38,8 @@
             android:text="@string/nickname_input_text"
             android:textColor="@color/black"
             android:textSize="@dimen/font_label_large"
+            app:layout_constraintVertical_chainStyle="packed"
+            app:layout_constraintBottom_toTopOf="@id/tl_nickname_input"
             app:layout_constraintStart_toStartOf="@+id/tl_nickname_input"
             app:layout_constraintTop_toBottomOf="@+id/iv_nickname_thumb" />
 
@@ -49,29 +54,32 @@
             app:boxStrokeErrorColor="@android:color/holo_red_dark"
             app:errorEnabled="true"
             app:errorIconDrawable="@null"
+            app:layout_constraintBottom_toTopOf="@+id/btn_nickname_apply"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/tv_nickname_input">
+            app:layout_constraintTop_toBottomOf="@id/tv_nickname_input"
+            app:layout_constraintVertical_bias="0.0">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/et_nickname_input"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:afterTextChanged="@{(e) -> vm.checkNicknameState(String.valueOf(e))}"
                 android:maxLength="10"
                 android:maxLines="1"
                 android:text="@={vm.nickname}"
                 android:textSize="@dimen/font_body_medium"
-                android:afterTextChanged="@{(e) -> vm.checkNicknameState(String.valueOf(e))}"
                 tools:ignore="SpeakableTextPresentCheck" />
         </com.google.android.material.textfield.TextInputLayout>
 
         <com.google.android.material.button.MaterialButton
-            android:id="@+id/button"
+            android:id="@+id/btn_nickname_apply"
             style="@style/Theme.UCMC.BottomButton"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:text="@string/nickname_btn_apply"
             android:enabled="@{vm.nicknameState == NicknameState.GREAT}"
+            android:onClick="@{() -> vm.updateNickname()}"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent" />

--- a/presentation/src/main/res/navigation/nav_main.xml
+++ b/presentation/src/main/res/navigation/nav_main.xml
@@ -25,7 +25,11 @@
         android:id="@+id/myPageFragment"
         android:name="com.gta.presentation.ui.mypage.MyPageFragment"
         android:label="@string/my_page"
-        tools:layout="@layout/fragment_mypage" />
+        tools:layout="@layout/fragment_mypage" >
+        <action
+            android:id="@+id/action_myPageFragment_to_nicknameFragment"
+            app:destination="@id/nicknameFragment" />
+    </fragment>
     <fragment
         android:id="@+id/carDetailFragment"
         android:name="com.gta.presentation.ui.cardetail.CarDetailFragment"
@@ -91,6 +95,14 @@
             app:destination="@id/carDetailFragment" />
         <argument
             android:name="OWNER_ID"
+            app:argType="string" />
+    </fragment>
+    <fragment
+        android:id="@+id/nicknameFragment"
+        android:name="com.gta.presentation.ui.nickname.NicknameFragment"
+        android:label="NicknameFragment" >
+        <argument
+            android:name="thumb"
             app:argType="string" />
     </fragment>
 

--- a/presentation/src/main/res/navigation/nav_main.xml
+++ b/presentation/src/main/res/navigation/nav_main.xml
@@ -104,6 +104,11 @@
         <argument
             android:name="thumb"
             app:argType="string" />
+        <action
+            android:id="@+id/action_nicknameFragment_to_myPageFragment"
+            app:destination="@id/myPageFragment"
+            app:popUpTo="@id/myPageFragment"
+            app:popUpToInclusive="true" />
     </fragment>
 
 </navigation>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -77,7 +77,7 @@
     <string name="mypage_btn_terms">이용 약관</string>
     <string name="mypage_btn_sign_out">로그아웃</string>
 
-    <style name="nickname_toolbar">닉네임 변경</style>
+    <string name="nickname_toolbar">닉네임 변경</string>
     <string name="nickname_input_text">닉네임</string>
     <string name="nickname_condition">한글, 영어, 숫자만 사용 가능해요 (2~10자)</string>
     <string name="nickname_error_min_length">닉네임은 2자 이상 입력해주세요</string>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -76,4 +76,11 @@
     <string name="mypage_title_other">기타</string>
     <string name="mypage_btn_terms">이용 약관</string>
     <string name="mypage_btn_sign_out">로그아웃</string>
+
+    <style name="nickname_toolbar">닉네임 변경</style>
+    <string name="nickname_input_text">닉네임</string>
+    <string name="nickname_condition">한글, 영어, 숫자만 사용 가능해요 (2~10자)</string>
+    <string name="nickname_error_min_length">닉네임은 2자 이상 입력해주세요</string>
+    <string name="nickname_error_symbols">한글, 영어, 숫자만 입력해주세요</string>
+    <string name="nickname_btn_apply">적용하기</string>
 </resources>


### PR DESCRIPTION
## 개요
- 닉네임 변경, 로그아웃 기능 추가

## 작업사항
- 닉네임 변경 기능 추가
- 로그아웃 기능 추가

## 변경된 부분
- UserInfo
  - icon의 기본 값을 빈 값으로 바꿨습니다.
- 스트링 리쏘스, navigation graph 수정
- MainActivity에 AuthStateListener 추가
  - signOut에 의해 currentUser가 null로 잡히면 로그인 화면으로 이동합니다.

## 실행 화면
### 로그아웃
![로그아웃](https://user-images.githubusercontent.com/90435036/203241219-9ccf7ec6-a4e3-41d6-97d9-39319959be60.gif)

### 닉네임 변경
![닉네임](https://user-images.githubusercontent.com/90435036/203241260-bc928d44-4081-4bd8-91bd-d2b3f4561558.gif)

## 특이사항
![97132146706137827949dbdc9993d6c5](https://user-images.githubusercontent.com/90435036/203242156-9c1d17c4-cbb6-443d-a4b5-4bbca33e2808.gif)
