### PR TITLE
feature: #75 datasource를 callbackflow로 마이그레이션

### DIFF
--- a/data/src/main/java/com/gta/data/repository/CarRepositoryImpl.kt
+++ b/data/src/main/java/com/gta/data/repository/CarRepositoryImpl.kt
@@ -1,8 +1,6 @@
 package com.gta.data.repository
 
-import com.google.firebase.firestore.QuerySnapshot
 import com.gta.data.model.Car
-import com.gta.data.model.UserInfo
 import com.gta.data.model.toCarRentInfo
 import com.gta.data.model.toDetailCar
 import com.gta.data.model.toProfile
@@ -10,17 +8,16 @@ import com.gta.data.model.toSimple
 import com.gta.data.source.CarDataSource
 import com.gta.data.source.ReservationDataSource
 import com.gta.data.source.UserDataSource
-import com.gta.domain.model.AvailableDate
 import com.gta.domain.model.CarDetail
 import com.gta.domain.model.CarRentInfo
 import com.gta.domain.model.RentState
-import com.gta.domain.model.Reservation
 import com.gta.domain.model.SimpleCar
 import com.gta.domain.model.UserProfile
 import com.gta.domain.repository.CarRepository
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
@@ -38,115 +35,62 @@ class CarRepositoryImpl @Inject constructor(
     }
 
     override fun getCarData(carId: String): Flow<CarDetail> = callbackFlow {
-        carDataSource.getCar(carId).addOnSuccessListener { carSnapshot ->
-            carSnapshot?.toObject(Car::class.java)?.let { carInfo ->
-                userDataSource.getUser(carInfo.ownerId).addOnSuccessListener { ownerSnapshot ->
-                    ownerSnapshot?.toObject(UserInfo::class.java)?.let { ownerInfo ->
-                        trySend(
-                            carInfo.toDetailCar(
-                                carSnapshot.id,
-                                ownerInfo.toProfile(carInfo.ownerId)
-                            )
-                        )
-                    } ?: trySend(CarDetail())
-                }.addOnFailureListener {
-                    trySend(CarDetail())
-                }
+        carDataSource.getCar(carId).first()?.let { car ->
+            userDataSource.getUser(car.ownerId).first()?.let { ownerInfo ->
+                trySend(
+                    car.toDetailCar(
+                        car.pinkSlip.informationNumber,
+                        ownerInfo.toProfile(car.ownerId)
+                    )
+                )
             } ?: trySend(CarDetail())
-        }.addOnFailureListener {
-            trySend(CarDetail())
-        }
+        } ?: trySend(CarDetail())
         awaitClose()
     }
 
     override fun getCarRentInfo(carId: String): Flow<CarRentInfo> = callbackFlow {
-        carDataSource.getCar(carId).addOnSuccessListener { carSnapshot ->
-            carSnapshot?.toObject(Car::class.java)?.let { car ->
-                reservationDataSource.getAllReservations().addOnSuccessListener { collection ->
-                    getCarReservationDates(collection, car).also { reservationDates ->
-                        trySend(car.toCarRentInfo(reservationDates))
-                    }
-                }
-            }
-        }.addOnFailureListener {
-            trySend(CarRentInfo())
-        }
+        carDataSource.getCar(carId).first()?.let { car ->
+            trySend(car.toCarRentInfo(reservationDataSource.getCarReservationDates(car).first()))
+        } ?: trySend(CarRentInfo())
         awaitClose()
     }
 
-    private fun getCarReservationDates(collection: QuerySnapshot, car: Car): List<AvailableDate> {
-        return collection.filter { document ->
-            car.reservations.contains(document.id)
-        }.map { document ->
-            document.toObject(Reservation::class.java).reservationDate
-        }
-    }
-
     private fun getCar(carId: String): Flow<Car> = callbackFlow {
-        carDataSource.getCar(carId).addOnSuccessListener { snapshot ->
-            snapshot?.toObject(Car::class.java)?.let {
-                trySend(it)
-            } ?: trySend(Car())
-        }.addOnFailureListener {
-            trySend(Car())
-        }
+        val car = carDataSource.getCar(carId).first() ?: Car()
+        trySend(car)
         awaitClose()
     }
 
     override fun getSimpleCarList(ownerId: String): Flow<List<SimpleCar>> = callbackFlow {
-        userDataSource.getUser(ownerId).addOnSuccessListener { user ->
-            if (user.exists()) {
-                val ownerCars = user.toObject(UserInfo::class.java)?.myCars
-                if (ownerCars == null) {
-                    trySend(listOf())
-                } else {
-                    carDataSource.getOwnerCars(ownerCars).addOnSuccessListener {
-                        it.map { car ->
-                            car.toObject(Car::class.java).toSimple(car.id)
-                        }.also { result ->
-                            trySend(result)
-                        }
-                    }.addOnFailureListener {
-                        trySend(emptyList())
-                    }
+        userDataSource.getUser(ownerId).first()?.let { userInfo ->
+            if (userInfo.myCars.isNotEmpty()) {
+                carDataSource.getOwnerCars(userInfo.myCars).first().map { car ->
+                    car.toSimple(car.pinkSlip.informationNumber)
+                }.also { result ->
+                    trySend(result)
                 }
+            } else {
+                trySend(emptyList())
             }
-        }.addOnFailureListener {
-            trySend(emptyList())
-        }
+        } ?: trySend(emptyList())
         awaitClose()
     }
 
     override fun getAllCars(): Flow<List<SimpleCar>> = callbackFlow {
-        carDataSource.getAllCars().addOnSuccessListener { query ->
-            val list = mutableListOf<SimpleCar>()
-            query.forEach { car ->
-                list.add(car.toObject(Car::class.java).toSimple(car.id))
-            }
-            trySend(list)
-        }.addOnFailureListener {
-            trySend(emptyList())
-        }
+        val cars = carDataSource.getAllCars().first()
+        trySend(cars.map { it.toSimple(it.pinkSlip.informationNumber) })
         awaitClose()
     }
 
     override fun removeCar(userId: String, carId: String): Flow<Boolean> = callbackFlow {
-        carDataSource.removeCar(carId).addOnSuccessListener {
-            userDataSource.getUser(userId).addOnSuccessListener { snapshot ->
-                val myCars = snapshot.get("myCars") as List<String>
-                val newCars = myCars.filter { it != carId }
-                userDataSource.removeCar(userId, newCars).addOnSuccessListener {
-                    trySend(true)
-                }.addOnFailureListener {
-                    trySend(false)
-                }
-            }.addOnFailureListener {
-                trySend(false)
-            }
-        }.addOnFailureListener {
+        if (carDataSource.removeCar(carId).first()) {
+            userDataSource.getUser(userId).first()?.let { userInfo ->
+                val newCars = userInfo.myCars.filter { it != carId }
+                trySend(userDataSource.removeCar(userId, newCars).first())
+            } ?: trySend(false)
+        } else {
             trySend(false)
         }
-
         awaitClose()
     }
 }

--- a/data/src/main/java/com/gta/data/repository/LicenseRepositoryImpl.kt
+++ b/data/src/main/java/com/gta/data/repository/LicenseRepositoryImpl.kt
@@ -6,6 +6,7 @@ import com.gta.domain.repository.LicenseRepository
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.first
 import java.nio.ByteBuffer
 import javax.inject.Inject
 
@@ -29,9 +30,7 @@ class LicenseRepositoryImpl @Inject constructor(
     }
 
     override fun setLicense(uid: String, license: DrivingLicense): Flow<Boolean> = callbackFlow {
-        dataSource.registerLicense(uid, license).addOnCompleteListener { result ->
-            trySend(result.isSuccessful)
-        }
+        trySend(dataSource.registerLicense(uid, license).first())
         awaitClose()
     }
 }

--- a/data/src/main/java/com/gta/data/repository/LoginRepositoryImpl.kt
+++ b/data/src/main/java/com/gta/data/repository/LoginRepositoryImpl.kt
@@ -6,6 +6,7 @@ import com.gta.domain.repository.LoginRepository
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.first
 import javax.inject.Inject
 
 class LoginRepositoryImpl @Inject constructor(
@@ -15,16 +16,11 @@ class LoginRepositoryImpl @Inject constructor(
     override fun checkCurrentUser(
         uid: String
     ): Flow<Boolean> = callbackFlow {
-        userDataSource.getUser(uid).addOnSuccessListener { snapshot ->
-            if (snapshot.exists()) {
-                trySend(true)
-            } else {
-                loginDataSource.createUser(uid).addOnCompleteListener { result ->
-                    trySend(result.isSuccessful)
-                }
-            }
-        }.addOnFailureListener {
-            trySend(false)
+        val userInfo = userDataSource.getUser(uid).first()
+        if (userInfo != null) {
+            trySend(true)
+        } else {
+            trySend(loginDataSource.createUser(uid).first())
         }
         awaitClose()
     }

--- a/data/src/main/java/com/gta/data/repository/NicknameRepositoryImpl.kt
+++ b/data/src/main/java/com/gta/data/repository/NicknameRepositoryImpl.kt
@@ -6,6 +6,7 @@ import com.gta.domain.repository.NicknameRepository
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.first
 import javax.inject.Inject
 
 class NicknameRepositoryImpl @Inject constructor(
@@ -19,9 +20,7 @@ class NicknameRepositoryImpl @Inject constructor(
         }
 
     override fun updateNickname(uid: String, nickname: String): Flow<Boolean> = callbackFlow {
-        dataSource.updateNickname(uid, nickname).addOnCompleteListener {
-            trySend(it.isSuccessful)
-        }
+        trySend(dataSource.updateNickname(uid, nickname).first())
         awaitClose()
     }
 

--- a/data/src/main/java/com/gta/data/repository/PinkSlipRepositoryImpl.kt
+++ b/data/src/main/java/com/gta/data/repository/PinkSlipRepositoryImpl.kt
@@ -1,6 +1,5 @@
 package com.gta.data.repository
 
-import com.google.firebase.firestore.DocumentSnapshot
 import com.gta.data.source.PinkSlipDataSource
 import com.gta.data.source.UserDataSource
 import com.gta.domain.model.PinkSlip
@@ -8,6 +7,7 @@ import com.gta.domain.repository.PinkSlipRepository
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.first
 import java.nio.ByteBuffer
 import javax.inject.Inject
 
@@ -27,21 +27,12 @@ class PinkSlipRepositoryImpl @Inject constructor(
             2. 리스트 뒤에 새로운 차의 ID 붙이고 업데이트
             3. 차 테이블에 새로운 차 추가
          */
-        userDataSource.getUser(uid).addOnSuccessListener { snapshot ->
-            val updatedCars = getUpdatedCars(snapshot, pinkSlip.informationNumber)
-            pinkSlipDataSource.updateCars(uid, updatedCars).addOnSuccessListener {
-                pinkSlipDataSource.createCar(uid, pinkSlip).addOnCompleteListener {
-                    trySend(it.isSuccessful)
-                }
-            }.addOnFailureListener {
-                trySend(false)
+        userDataSource.getUser(uid).first()?.let { userInfo ->
+            val updatedCars = userInfo.myCars.plus(pinkSlip.informationNumber)
+            pinkSlipDataSource.run {
+                trySend(updateCars(uid, updatedCars).first() && createCar(uid, pinkSlip).first())
             }
-        }.addOnCompleteListener {
-            trySend(false)
-        }
+        } ?: trySend(false)
         awaitClose()
     }
-
-    private fun getUpdatedCars(snapshot: DocumentSnapshot, informationNumber: String) =
-        (snapshot["myCars"] as? List<*>)?.plus(informationNumber) ?: listOf(informationNumber)
 }

--- a/data/src/main/java/com/gta/data/repository/ReviewRepositoryImpl.kt
+++ b/data/src/main/java/com/gta/data/repository/ReviewRepositoryImpl.kt
@@ -1,21 +1,18 @@
 package com.gta.data.repository
 
-import com.gta.data.model.Car
-import com.gta.data.model.UserInfo
 import com.gta.data.model.toProfile
 import com.gta.data.source.CarDataSource
 import com.gta.data.source.ReservationDataSource
 import com.gta.data.source.ReviewDataSource
 import com.gta.data.source.UserDataSource
-import com.gta.domain.model.Reservation
 import com.gta.domain.model.ReviewDTO
 import com.gta.domain.model.ReviewType
-import com.gta.domain.model.UserProfile
 import com.gta.domain.model.UserReview
 import com.gta.domain.repository.ReviewRepository
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.first
 import javax.inject.Inject
 
 class ReviewRepositoryImpl @Inject constructor(
@@ -34,18 +31,13 @@ class ReviewRepositoryImpl @Inject constructor(
             2. 상대방 정보를 불러온다.
             3. 온도를 갱신한다.
          */
-        reviewDataSource.addReview(opponentId, reservationId, review).addOnSuccessListener {
-            userDataSource.getUser(opponentId).addOnSuccessListener { userSnapshot ->
-                userSnapshot.toObject(UserInfo::class.java)?.let { userInfo ->
-                    val updatedTemperature = userInfo.temperature + calcTemperature(review.rating)
-                    reviewDataSource.updateTemperature(opponentId, updatedTemperature).addOnCompleteListener {
-                        trySend(it.isSuccessful)
-                    }
-                } ?: trySend(false)
-            }.addOnFailureListener {
-                trySend(false)
-            }
-        }.addOnFailureListener {
+        val addReviewResult = reviewDataSource.addReview(opponentId, reservationId, review).first()
+        if (addReviewResult) {
+            userDataSource.getUser(opponentId).first()?.let { userInfo ->
+                val updatedTemperature = userInfo.temperature + calcTemperature(review.rating)
+                trySend(reviewDataSource.updateTemperature(opponentId, updatedTemperature).first())
+            } ?: trySend(false)
+        } else {
             trySend(false)
         }
         awaitClose()
@@ -59,15 +51,13 @@ class ReviewRepositoryImpl @Inject constructor(
             3-1. 같으면 대여자 -> 차주에게 리뷰를 보내는 케이스 (차 정보의 ownerId에서 UserProfile 얻기)
             3-2. 다르면 차주 -> 대여자에게 리뷰를 보내는 케이스 (예약의 userId에서 UserProfile 얻기)
          */
-        reservationDataSource.getReservation(reservationId).addOnSuccessListener { reservationSnapshot ->
-            val reservation = reservationSnapshot.toObject(Reservation::class.java) ?: Reservation()
+        reservationDataSource.getReservation(reservationId).first()?.let { reservation ->
             val reviewType = if (reservation.userId == uid) ReviewType.LENDER_TO_OWNER else ReviewType.OWNER_TO_LENDER
-            carDataSource.getCar(reservation.carId).addOnSuccessListener { carSnapshot ->
-                val car = carSnapshot.toObject(Car::class.java) ?: Car()
+            carDataSource.getCar(reservation.carId).first()?.let { car ->
                 val carImage = if (car.images.isNotEmpty()) car.images[0] else ""
                 val opponentId = if (reviewType == ReviewType.LENDER_TO_OWNER) car.ownerId else reservation.userId
-                userDataSource.getUser(opponentId).addOnSuccessListener { userSnapshot ->
-                    val profile = userSnapshot?.toObject(UserInfo::class.java)?.toProfile(opponentId) ?: UserProfile()
+                userDataSource.getUser(opponentId).first()?.let { userInfo ->
+                    val profile = userInfo.toProfile(opponentId)
                     trySend(
                         ReviewDTO(
                             reviewType = reviewType,
@@ -76,15 +66,9 @@ class ReviewRepositoryImpl @Inject constructor(
                             carModel = car.pinkSlip.model
                         )
                     )
-                }.addOnFailureListener {
-                    trySend(ReviewDTO())
-                }
-            }.addOnFailureListener {
-                trySend(ReviewDTO())
-            }
-        }.addOnFailureListener {
-            trySend(ReviewDTO())
-        }
+                } ?: trySend(ReviewDTO())
+            } ?: trySend(ReviewDTO())
+        } ?: trySend(ReviewDTO())
         awaitClose()
     }
 

--- a/data/src/main/java/com/gta/data/source/LicenseDataSource.kt
+++ b/data/src/main/java/com/gta/data/source/LicenseDataSource.kt
@@ -1,13 +1,19 @@
 package com.gta.data.source
 
-import com.google.android.gms.tasks.Task
 import com.google.firebase.firestore.FirebaseFirestore
 import com.gta.domain.model.DrivingLicense
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
 import javax.inject.Inject
 
 class LicenseDataSource @Inject constructor(
     private val fireStore: FirebaseFirestore
 ) {
-    fun registerLicense(uid: String, license: DrivingLicense): Task<Void> =
-        fireStore.collection("users").document(uid).update("license", license)
+    fun registerLicense(uid: String, license: DrivingLicense): Flow<Boolean> = callbackFlow {
+        fireStore.collection("users").document(uid).update("license", license).addOnCompleteListener {
+            trySend(it.isSuccessful)
+        }
+        awaitClose()
+    }
 }

--- a/data/src/main/java/com/gta/data/source/LoginDataSource.kt
+++ b/data/src/main/java/com/gta/data/source/LoginDataSource.kt
@@ -1,16 +1,23 @@
 package com.gta.data.source
 
-import com.google.android.gms.tasks.Task
 import com.google.firebase.firestore.FirebaseFirestore
 import com.gta.data.model.UserInfo
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
 import javax.inject.Inject
 
 class LoginDataSource @Inject constructor(
     private val fireStore: FirebaseFirestore
 ) {
-    fun createUser(uid: String): Task<Void> =
+    fun createUser(uid: String): Flow<Boolean> = callbackFlow {
         fireStore
             .collection("users")
             .document(uid)
             .set(UserInfo(chatId = uid.hashCode().toLong()))
+            .addOnCompleteListener {
+                trySend(it.isSuccessful)
+            }
+        awaitClose()
+    }
 }

--- a/data/src/main/java/com/gta/data/source/MyPageDataSource.kt
+++ b/data/src/main/java/com/gta/data/source/MyPageDataSource.kt
@@ -1,12 +1,18 @@
 package com.gta.data.source
 
-import com.google.android.gms.tasks.Task
 import com.google.firebase.firestore.FirebaseFirestore
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
 import javax.inject.Inject
 
 class MyPageDataSource @Inject constructor(
     private val fireStore: FirebaseFirestore
 ) {
-    fun setThumbnail(uid: String, downloadUrl: String): Task<Void> =
-        fireStore.collection("users").document(uid).update("icon", downloadUrl)
+    fun setThumbnail(uid: String, downloadUrl: String): Flow<Boolean> = callbackFlow {
+        fireStore.collection("users").document(uid).update("icon", downloadUrl).addOnCompleteListener {
+            trySend(it.isSuccessful)
+        }
+        awaitClose()
+    }
 }

--- a/data/src/main/java/com/gta/data/source/NicknameDataSource.kt
+++ b/data/src/main/java/com/gta/data/source/NicknameDataSource.kt
@@ -1,12 +1,18 @@
 package com.gta.data.source
 
-import com.google.android.gms.tasks.Task
 import com.google.firebase.firestore.FirebaseFirestore
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
 import javax.inject.Inject
 
 class NicknameDataSource @Inject constructor(
     private val fireStore: FirebaseFirestore
 ) {
-    fun updateNickname(uid: String, nickname: String): Task<Void> =
-        fireStore.collection("users").document(uid).update("nickname", nickname)
+    fun updateNickname(uid: String, nickname: String): Flow<Boolean> = callbackFlow {
+        fireStore.collection("users").document(uid).update("nickname", nickname).addOnCompleteListener {
+            trySend(it.isSuccessful)
+        }
+        awaitClose()
+    }
 }

--- a/data/src/main/java/com/gta/data/source/PinkSlipDataSource.kt
+++ b/data/src/main/java/com/gta/data/source/PinkSlipDataSource.kt
@@ -1,9 +1,11 @@
 package com.gta.data.source
 
-import com.google.android.gms.tasks.Task
 import com.google.firebase.firestore.FirebaseFirestore
 import com.gta.data.model.Car
 import com.gta.domain.model.PinkSlip
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
 import javax.inject.Inject
 import kotlin.random.Random
 
@@ -41,14 +43,23 @@ class PinkSlipDataSource @Inject constructor(
         .random(Random(System.currentTimeMillis()))
         .copy(informationNumber = getRandomInformationNumber())
 
-    fun updateCars(uid: String, cars: List<Any?>): Task<Void> =
-        fireStore.collection("users").document(uid).update("myCars", cars)
+    fun updateCars(uid: String, cars: List<Any?>): Flow<Boolean> = callbackFlow {
+        fireStore.collection("users").document(uid).update("myCars", cars).addOnCompleteListener {
+            trySend(it.isSuccessful)
+        }
+        awaitClose()
+    }
 
-    fun createCar(uid: String, pinkSlip: PinkSlip): Task<Void> =
+    fun createCar(uid: String, pinkSlip: PinkSlip): Flow<Boolean> = callbackFlow {
         fireStore
             .collection("cars")
             .document(pinkSlip.informationNumber)
             .set(Car(ownerId = uid, pinkSlip = pinkSlip))
+            .addOnCompleteListener {
+                trySend(it.isSuccessful)
+            }
+        awaitClose()
+    }
 
     companion object {
         private const val INFORMATION_NUMBER_LENGTH = 17

--- a/data/src/main/java/com/gta/data/source/ReservationDataSource.kt
+++ b/data/src/main/java/com/gta/data/source/ReservationDataSource.kt
@@ -1,24 +1,61 @@
 package com.gta.data.source
 
-import com.google.android.gms.tasks.Task
-import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.FirebaseFirestore
-import com.google.firebase.firestore.QuerySnapshot
+import com.gta.data.model.Car
+import com.gta.domain.model.AvailableDate
 import com.gta.domain.model.Reservation
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
 import javax.inject.Inject
 
 class ReservationDataSource @Inject constructor(private val fireStore: FirebaseFirestore) {
-    fun createReservation(reservation: Reservation, reservationId: String): Task<Void> {
-        return fireStore
+    fun createReservation(reservation: Reservation, reservationId: String): Flow<Boolean> = callbackFlow {
+        fireStore
             .collection("reservations")
             .document(reservationId)
             .set(reservation)
+            .addOnCompleteListener {
+                trySend(it.isSuccessful)
+            }
+        awaitClose()
     }
 
     // TODO addSnapshotListener
-    fun getReservation(reservationId: String): Task<DocumentSnapshot> =
-        fireStore.collection("reservations").document(reservationId).get()
+    fun getReservation(reservationId: String): Flow<Reservation?> = callbackFlow {
+        fireStore.collection("reservations").document(reservationId).get().addOnCompleteListener {
+            if (it.isSuccessful) {
+                trySend(it.result.toObject(Reservation::class.java))
+            } else {
+                trySend(null)
+            }
+        }
+        awaitClose()
+    }
 
-    fun getAllReservations(): Task<QuerySnapshot> =
-        fireStore.collection("reservations").get()
+    fun getAllReservations(): Flow<List<Reservation>> = callbackFlow {
+        fireStore.collection("reservations").get().addOnCompleteListener {
+            if (it.isSuccessful) {
+                trySend(it.result.map { snapshot -> snapshot.toObject(Reservation::class.java) })
+            } else {
+                trySend(emptyList())
+            }
+        }
+        awaitClose()
+    }
+
+    fun getCarReservationDates(car: Car): Flow<List<AvailableDate>> = callbackFlow {
+        fireStore.collection("reservations").get().addOnCompleteListener {
+            if (it.isSuccessful) {
+                it.result.filter { document ->
+                    car.reservations.contains(document.id)
+                }.map { snapshot ->
+                    snapshot.toObject(Reservation::class.java).reservationDate
+                }
+            } else {
+                trySend(emptyList())
+            }
+        }
+        awaitClose()
+    }
 }

--- a/data/src/main/java/com/gta/data/source/ReviewDataSource.kt
+++ b/data/src/main/java/com/gta/data/source/ReviewDataSource.kt
@@ -1,24 +1,36 @@
 package com.gta.data.source
 
-import com.google.android.gms.tasks.Task
 import com.google.firebase.firestore.FirebaseFirestore
 import com.gta.domain.model.UserReview
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
 import javax.inject.Inject
 
 class ReviewDataSource @Inject constructor(
     private val fireStore: FirebaseFirestore
 ) {
-    fun addReview(opponentId: String, reservationId: String, review: UserReview): Task<Void> =
+    fun addReview(opponentId: String, reservationId: String, review: UserReview): Flow<Boolean> = callbackFlow {
         fireStore
             .collection("users")
             .document(opponentId)
             .collection("reviews")
             .document(reservationId)
             .set(review)
+            .addOnCompleteListener {
+                trySend(it.isSuccessful)
+            }
+        awaitClose()
+    }
 
-    fun updateTemperature(opponentId: String, temperature: Float) =
+    fun updateTemperature(opponentId: String, temperature: Float): Flow<Boolean> = callbackFlow {
         fireStore
             .collection("users")
             .document(opponentId)
             .update("temperature", temperature)
+            .addOnCompleteListener {
+                trySend(it.isSuccessful)
+            }
+        awaitClose()
+    }
 }

--- a/data/src/main/java/com/gta/data/source/StorageDataSource.kt
+++ b/data/src/main/java/com/gta/data/source/StorageDataSource.kt
@@ -1,24 +1,37 @@
 package com.gta.data.source
 
 import android.net.Uri
-import com.google.android.gms.tasks.Task
 import com.google.firebase.storage.StorageReference
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
 import javax.inject.Inject
 
 class StorageDataSource @Inject constructor(
     private val storageReference: StorageReference
 ) {
-    fun uploadThumbnail(uri: String): Task<Uri> {
+    fun uploadThumbnail(uri: String): Flow<String?> = callbackFlow {
         val image = Uri.parse(uri)
         val name = image.path?.substringAfterLast("/") ?: ""
         val ref = storageReference
             .child("thumb")
             .child("${System.currentTimeMillis()}$name")
-        return ref.putFile(image).continueWithTask {
+        ref.putFile(image).continueWithTask {
             ref.downloadUrl
+        }.addOnCompleteListener {
+            if (it.isSuccessful) {
+                trySend(it.result.toString())
+            } else {
+                trySend(null)
+            }
         }
+        awaitClose()
     }
 
-    fun deleteThumbnail(path: String): Task<Void> =
-        storageReference.storage.getReferenceFromUrl(path).delete()
+    fun deleteThumbnail(path: String): Flow<Boolean> = callbackFlow {
+        storageReference.storage.getReferenceFromUrl(path).delete().addOnCompleteListener {
+            trySend(it.isSuccessful)
+        }
+        awaitClose()
+    }
 }

--- a/data/src/main/java/com/gta/data/source/UserDataSource.kt
+++ b/data/src/main/java/com/gta/data/source/UserDataSource.kt
@@ -1,16 +1,30 @@
 package com.gta.data.source
 
-import com.google.android.gms.tasks.Task
-import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.FirebaseFirestore
+import com.gta.data.model.UserInfo
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
 import javax.inject.Inject
 
 class UserDataSource @Inject constructor(
     private val fireStore: FirebaseFirestore
 ) {
-    fun getUser(uid: String): Task<DocumentSnapshot> =
-        fireStore.collection("users").document(uid).get()
+    fun getUser(uid: String): Flow<UserInfo?> = callbackFlow {
+        fireStore.collection("users").document(uid).get().addOnCompleteListener {
+            if (it.isSuccessful) {
+                trySend(it.result.toObject(UserInfo::class.java))
+            } else {
+                trySend(null)
+            }
+        }
+        awaitClose()
+    }
 
-    fun removeCar(uid: String, newCars: List<String>): Task<Void> =
-        fireStore.collection("users").document(uid).update("myCars", newCars)
+    fun removeCar(uid: String, newCars: List<String>): Flow<Boolean> = callbackFlow {
+        fireStore.collection("users").document(uid).update("myCars", newCars).addOnCompleteListener {
+            trySend(it.isSuccessful)
+        }
+        awaitClose()
+    }
 }

--- a/presentation/src/main/java/com/gta/presentation/ui/BindingAdapter.kt
+++ b/presentation/src/main/java/com/gta/presentation/ui/BindingAdapter.kt
@@ -4,7 +4,6 @@ import android.widget.Button
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.databinding.BindingAdapter
-import androidx.swiperefreshlayout.widget.CircularProgressDrawable
 import com.gta.domain.model.AvailableDate
 import com.gta.domain.usecase.cardetail.UseState
 import com.gta.presentation.R

--- a/presentation/src/main/res/navigation/nav_main.xml
+++ b/presentation/src/main/res/navigation/nav_main.xml
@@ -3,7 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/nav_main"
-    app:startDestination="@id/reviewFragment">
+    app:startDestination="@id/mapFragment">
 
     <fragment
         android:id="@+id/mapFragment"


### PR DESCRIPTION
## 개요
- datasource를 callbackflow로 마이그레이션

## 작업사항
- datasource 메소드들의 반환값을 flow로 변경

## 변경된 부분
- data모듈의 repository와 datasource

## 실행 화면
- 업슴

## 특이사항
- 각자가 만든 repository들을 찬찬히 보면서 의미가 달라진 부분이 있나 확인해주십시요
- repository에서 snapshot의 key를 활용하는 부분이 있던데 이제는 datasource안에서 처리해야합니다.