### PR TITLE
Feature: #33 차 상세 페이지 이미지

### DIFF
--- a/buildSrc/src/main/java/com/gta/buildsrc/Dependencies.kt
+++ b/buildSrc/src/main/java/com/gta/buildsrc/Dependencies.kt
@@ -47,6 +47,9 @@ object Dependencies {
         const val JUNIT = "4.13.2"
         const val JUNIT_EXT = "1.1.4"
         const val ESPRESSO_CORE = "3.5.0"
+
+        //Github open Library
+        const val INDICATOR = "4.3"
     }
 
     object Classpaths {
@@ -171,6 +174,8 @@ object Dependencies {
             }
         }
 
+        const val INDICATOR = "com.tbuonomo:dotsindicator:${Versions.INDICATOR}"
+
         const val VIEW_PAGER_2 = "androidx.viewpager2:viewpager2:${Versions.VIEW_PAGER}"
 
         const val NAVER_MAP = "com.naver.maps:map-sdk:${Versions.NAVER_MAPS}"
@@ -237,6 +242,7 @@ object Dependencies {
             add(NAVER_MAP)
             add(STREAM_CHAT)
             add(TIMBER)
+            add(INDICATOR)
         }
 
         val presentationKaptLibraries = arrayListOf<String>().apply {

--- a/presentation/src/main/java/com/gta/presentation/ui/cardetail/CarDetailFragment.kt
+++ b/presentation/src/main/java/com/gta/presentation/ui/cardetail/CarDetailFragment.kt
@@ -34,6 +34,7 @@ class CarDetailFragment : BaseFragment<FragmentCarDetailBinding>(
         super.onCreateView(inflater, container, savedInstanceState)
         binding.vm = viewModel
         binding.vpImages.adapter = pagerAdapter
+        binding.indicatorImages.attachTo(binding.vpImages)
         return binding.root
     }
 
@@ -45,6 +46,7 @@ class CarDetailFragment : BaseFragment<FragmentCarDetailBinding>(
                 viewModel.carInfo.collectLatest {
                     (requireActivity() as MainActivity).supportActionBar?.title = it.licensePlate
                     pagerAdapter.submitList(it.images)
+                    binding.indicatorImages.attachTo(binding.vpImages)
                 }
             }
         }

--- a/presentation/src/main/java/com/gta/presentation/ui/cardetail/CarDetailFragment.kt
+++ b/presentation/src/main/java/com/gta/presentation/ui/cardetail/CarDetailFragment.kt
@@ -5,12 +5,17 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.fragment.findNavController
 import com.gta.domain.usecase.cardetail.UseState
 import com.gta.presentation.R
 import com.gta.presentation.databinding.FragmentCarDetailBinding
 import com.gta.presentation.ui.base.BaseFragment
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class CarDetailFragment : BaseFragment<FragmentCarDetailBinding>(
@@ -18,6 +23,7 @@ class CarDetailFragment : BaseFragment<FragmentCarDetailBinding>(
 ) {
 
     private val viewModel: CarDetailViewModel by viewModels()
+    private val pagerAdapter by lazy { CarImagePagerAdapter() }
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -26,11 +32,20 @@ class CarDetailFragment : BaseFragment<FragmentCarDetailBinding>(
     ): View {
         super.onCreateView(inflater, container, savedInstanceState)
         binding.vm = viewModel
+        binding.vpImages.adapter = pagerAdapter
         return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.carInfo.collectLatest {
+                    pagerAdapter.submitList(it.images)
+                }
+            }
+        }
 
         binding.cvOwner.setOnClickListener {
             findNavController().navigate(

--- a/presentation/src/main/java/com/gta/presentation/ui/cardetail/CarDetailFragment.kt
+++ b/presentation/src/main/java/com/gta/presentation/ui/cardetail/CarDetailFragment.kt
@@ -46,7 +46,6 @@ class CarDetailFragment : BaseFragment<FragmentCarDetailBinding>(
                 viewModel.carInfo.collectLatest {
                     (requireActivity() as MainActivity).supportActionBar?.title = it.licensePlate
                     pagerAdapter.submitList(it.images)
-                    binding.indicatorImages.attachTo(binding.vpImages)
                 }
             }
         }

--- a/presentation/src/main/java/com/gta/presentation/ui/cardetail/CarDetailFragment.kt
+++ b/presentation/src/main/java/com/gta/presentation/ui/cardetail/CarDetailFragment.kt
@@ -12,6 +12,7 @@ import androidx.navigation.fragment.findNavController
 import com.gta.domain.usecase.cardetail.UseState
 import com.gta.presentation.R
 import com.gta.presentation.databinding.FragmentCarDetailBinding
+import com.gta.presentation.ui.MainActivity
 import com.gta.presentation.ui.base.BaseFragment
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
@@ -42,6 +43,7 @@ class CarDetailFragment : BaseFragment<FragmentCarDetailBinding>(
         lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.carInfo.collectLatest {
+                    (requireActivity() as MainActivity).supportActionBar?.title = it.licensePlate
                     pagerAdapter.submitList(it.images)
                 }
             }

--- a/presentation/src/main/java/com/gta/presentation/ui/cardetail/CarDetailViewModel.kt
+++ b/presentation/src/main/java/com/gta/presentation/ui/cardetail/CarDetailViewModel.kt
@@ -7,7 +7,6 @@ import com.google.firebase.auth.FirebaseAuth
 import com.gta.domain.model.CarDetail
 import com.gta.domain.usecase.cardetail.GetCarDetailDataUseCase
 import com.gta.domain.usecase.cardetail.GetUseStateAboutCarUseCase
-import com.gta.domain.usecase.cardetail.SetStateAtCarDetailUseCase
 import com.gta.domain.usecase.cardetail.UseState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.SharingStarted
@@ -21,7 +20,6 @@ class CarDetailViewModel @Inject constructor(
     args: SavedStateHandle,
     auth: FirebaseAuth,
     getCarDetailDataUseCase: GetCarDetailDataUseCase,
-    setStateAtCarDetailUseCase: SetStateAtCarDetailUseCase,
     getUseStateAboutCarUseCase: GetUseStateAboutCarUseCase
 ) : ViewModel() {
 

--- a/presentation/src/main/java/com/gta/presentation/ui/cardetail/CarDetailViewModel.kt
+++ b/presentation/src/main/java/com/gta/presentation/ui/cardetail/CarDetailViewModel.kt
@@ -3,11 +3,11 @@ package com.gta.presentation.ui.cardetail
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.google.firebase.auth.FirebaseAuth
 import com.gta.domain.model.CarDetail
 import com.gta.domain.usecase.cardetail.GetCarDetailDataUseCase
 import com.gta.domain.usecase.cardetail.GetUseStateAboutCarUseCase
 import com.gta.domain.usecase.cardetail.UseState
+import com.gta.presentation.util.FirebaseUtil
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -18,7 +18,6 @@ import javax.inject.Inject
 @HiltViewModel
 class CarDetailViewModel @Inject constructor(
     args: SavedStateHandle,
-    auth: FirebaseAuth,
     getCarDetailDataUseCase: GetCarDetailDataUseCase,
     getUseStateAboutCarUseCase: GetUseStateAboutCarUseCase
 ) : ViewModel() {
@@ -28,7 +27,7 @@ class CarDetailViewModel @Inject constructor(
 
     init {
         val carId = args.get<String>("CAR_ID") ?: "정보 없음"
-        val uid = auth.currentUser?.uid ?: "정보 없음"
+        val uid = FirebaseUtil.uid
 
         carInfo = getCarDetailDataUseCase(carId).stateIn(
             scope = viewModelScope,

--- a/presentation/src/main/java/com/gta/presentation/ui/cardetail/CarImagePagerAdapter.kt
+++ b/presentation/src/main/java/com/gta/presentation/ui/cardetail/CarImagePagerAdapter.kt
@@ -1,0 +1,47 @@
+package com.gta.presentation.ui.cardetail
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.databinding.DataBindingUtil
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView.ViewHolder
+import com.gta.presentation.R
+import com.gta.presentation.databinding.ItemCarDetailImageBinding
+
+class CarImagePagerAdapter :
+    ListAdapter<String, CarImagePagerAdapter.ImageViewHolder>(ImagesDiffCallback()) {
+
+    class ImageViewHolder(
+        private val binding: ItemCarDetailImageBinding
+    ) : ViewHolder(binding.root) {
+        fun bind(img: String) {
+            binding.img = img
+        }
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ImageViewHolder {
+        return ImageViewHolder(
+            DataBindingUtil.inflate(
+                LayoutInflater.from(parent.context),
+                R.layout.item_car_detail_image,
+                parent,
+                false
+            )
+        )
+    }
+
+    override fun onBindViewHolder(holder: ImageViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+}
+
+private class ImagesDiffCallback : DiffUtil.ItemCallback<String>() {
+    override fun areItemsTheSame(oldItem: String, newItem: String): Boolean {
+        return oldItem == newItem
+    }
+
+    override fun areContentsTheSame(oldItem: String, newItem: String): Boolean {
+        return oldItem == newItem
+    }
+}

--- a/presentation/src/main/res/layout/fragment_car_detail.xml
+++ b/presentation/src/main/res/layout/fragment_car_detail.xml
@@ -40,18 +40,16 @@
                     android:orientation="vertical"
                     app:layout_constraintGuide_end="@dimen/padding_medium" />
 
-                <com.google.android.material.imageview.ShapeableImageView
-                    android:id="@+id/iv_car"
+                <androidx.viewpager2.widget.ViewPager2
+                    android:id="@+id/vp_images"
                     android:layout_width="0dp"
-                    android:layout_height="wrap_content"
+                    android:layout_height="300dp"
                     android:layout_marginTop="@dimen/padding_large"
-                    android:adjustViewBounds="true"
                     android:elevation="1dp"
-                    android:src="@drawable/ic_logo"
                     app:layout_constraintEnd_toEndOf="@+id/gl_end"
                     app:layout_constraintStart_toStartOf="@+id/gl_start"
-                    app:layout_constraintTop_toTopOf="parent"
-                    app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.App.CornerSize5Percent" />
+                    app:layout_constraintTop_toTopOf="parent"/>
+
 
                 <com.google.android.material.textview.MaterialTextView
                     android:id="@+id/tv_title"
@@ -67,7 +65,7 @@
                     app:car_type="@{vm.carInfo.carType}"
                     app:layout_constraintEnd_toEndOf="@+id/gl_end"
                     app:layout_constraintStart_toStartOf="@id/gl_start"
-                    app:layout_constraintTop_toBottomOf="@+id/iv_car"
+                    app:layout_constraintTop_toBottomOf="@+id/vp_images"
                     tools:text="[차 종류] 이름 뭐시기" />
 
                 <com.google.android.material.textview.MaterialTextView

--- a/presentation/src/main/res/layout/fragment_car_detail.xml
+++ b/presentation/src/main/res/layout/fragment_car_detail.xml
@@ -6,6 +6,7 @@
     tools:context=".ui.cardetail.CarDetailFragment">
 
     <data>
+
         <variable
             name="vm"
             type="com.gta.presentation.ui.cardetail.CarDetailViewModel" />
@@ -45,11 +46,24 @@
                     android:layout_width="0dp"
                     android:layout_height="300dp"
                     android:layout_marginTop="@dimen/padding_large"
-                    android:elevation="1dp"
                     app:layout_constraintEnd_toEndOf="@+id/gl_end"
                     app:layout_constraintStart_toStartOf="@+id/gl_start"
-                    app:layout_constraintTop_toTopOf="parent"/>
+                    app:layout_constraintTop_toTopOf="parent" />
 
+                <com.tbuonomo.viewpagerdotsindicator.WormDotsIndicator
+                    android:id="@+id/indicator_images"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    app:dotsColor="?attr/colorSecondary"
+                    app:dotsStrokeColor="?attr/colorPrimary"
+                    app:dotsSize="@dimen/padding_small"
+                    app:dotsSpacing="4dp"
+                    app:dotsStrokeWidth="2dp"
+                    android:layout_marginBottom="@dimen/padding_small"
+                    app:layout_constraintStart_toStartOf="@+id/vp_images"
+                    app:layout_constraintEnd_toEndOf="@+id/vp_images"
+                    app:layout_constraintBottom_toBottomOf="@+id/vp_images"
+                    />
 
                 <com.google.android.material.textview.MaterialTextView
                     android:id="@+id/tv_title"
@@ -61,8 +75,8 @@
                     android:textSize="@dimen/font_headline_medium"
                     android:textStyle="bold"
                     app:car_title="@{vm.carInfo.model}"
-                    app:car_year="@{vm.carInfo.year}"
                     app:car_type="@{vm.carInfo.carType}"
+                    app:car_year="@{vm.carInfo.year}"
                     app:layout_constraintEnd_toEndOf="@+id/gl_end"
                     app:layout_constraintStart_toStartOf="@id/gl_start"
                     app:layout_constraintTop_toBottomOf="@+id/vp_images"
@@ -98,14 +112,13 @@
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/padding_extra_large"
+                    android:text="@{@string/car_detail_licensePlate(vm.carInfo.licensePlate)}"
                     android:textSize="@dimen/font_body_large"
                     android:textStyle="bold"
-                    android:text="@{@string/car_detail_licensePlate(vm.carInfo.licensePlate)}"
                     app:layout_constraintEnd_toEndOf="@+id/gl_end"
                     app:layout_constraintStart_toStartOf="@+id/gl_start"
                     app:layout_constraintTop_toBottomOf="@+id/tv_location"
                     tools:text="번호판 : 12가2345" />
-
 
                 <com.google.android.material.textview.MaterialTextView
                     android:id="@+id/tv_report_post"

--- a/presentation/src/main/res/layout/item_car_detail_image.xml
+++ b/presentation/src/main/res/layout/item_car_detail_image.xml
@@ -9,19 +9,14 @@
             type="String" />
     </data>
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+
+    <com.google.android.material.imageview.ShapeableImageView
+        android:id="@+id/iv_car"
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
-
-        <com.google.android.material.imageview.ShapeableImageView
-            android:id="@+id/iv_car"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:adjustViewBounds="true"
-            android:scaleType="center"
-            app:image_uri="@{img}" />
-
-    </androidx.constraintlayout.widget.ConstraintLayout>
+        android:layout_height="match_parent"
+        android:adjustViewBounds="true"
+        android:scaleType="center"
+        app:image_uri="@{img}" />
 
 
 </layout>

--- a/presentation/src/main/res/layout/item_car_detail_image.xml
+++ b/presentation/src/main/res/layout/item_car_detail_image.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <data>
+
+        <variable
+            name="img"
+            type="String" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <com.google.android.material.imageview.ShapeableImageView
+            android:id="@+id/iv_car"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:adjustViewBounds="true"
+            android:scaleType="center"
+            app:image_uri="@{img}" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+
+</layout>


### PR DESCRIPTION
## 개요
차 상세 페이지에서 차 이미지들을 보여주기 위한 작업

## 작업사항
- 차 상세 페이지 이미지 작업
- 차 상세 페이지 라벨에 차 번호판 보이기
- Firebase Util 사용

## 변경된 부분
- 차 이미지 ViewPager2 어뎁터
- ViewModel, Fragment, XML

## 실행 화면

https://user-images.githubusercontent.com/59998983/204286918-c038aa30-f639-4bd6-8b16-257bc50a79c5.mp4



## 특이사항
- FirebaseUtil 사용
- indicator 의존성 추가
- [viewpager indicator 오픈 라이브러리 사용](https://github.com/tommybuonomo/dotsindicator?utm_source=android-arsenal.com&utm_medium=referral&utm_campaign=7127)