### PR TITLE
Feature #100  : 앱 데이터 삭제 시 FCM 토큰 정보 업데이트

### DIFF
--- a/data/src/main/java/com/gta/data/repository/LoginRepositoryImpl.kt
+++ b/data/src/main/java/com/gta/data/repository/LoginRepositoryImpl.kt
@@ -38,4 +38,9 @@ class LoginRepositoryImpl @Inject constructor(
         }
         awaitClose()
     }
+
+    override suspend fun updateUserMessageToken(uid: String): Boolean {
+        val messageToken = messageTokenDataSource.getMessageToken().first()
+        return userDataSource.updateUserMessageToken(uid, messageToken).first()
+    }
 }

--- a/data/src/main/java/com/gta/data/source/UserDataSource.kt
+++ b/data/src/main/java/com/gta/data/source/UserDataSource.kt
@@ -27,4 +27,11 @@ class UserDataSource @Inject constructor(
         }
         awaitClose()
     }
+
+    fun updateUserMessageToken(uid: String, token: String) = callbackFlow {
+        fireStore.collection("users").document(uid).update("messageToken", token).addOnCompleteListener {
+            trySend(it.isSuccessful)
+        }
+        awaitClose()
+    }
 }

--- a/domain/src/main/java/com/gta/domain/repository/LoginRepository.kt
+++ b/domain/src/main/java/com/gta/domain/repository/LoginRepository.kt
@@ -6,4 +6,5 @@ import kotlinx.coroutines.flow.Flow
 interface LoginRepository {
     fun checkCurrentUser(uid: String): Flow<LoginResult>
     fun signUp(uid: String): Flow<LoginResult>
+    suspend fun updateUserMessageToken(uid: String): Boolean
 }

--- a/domain/src/main/java/com/gta/domain/usecase/login/CheckCurrentUserUseCase.kt
+++ b/domain/src/main/java/com/gta/domain/usecase/login/CheckCurrentUserUseCase.kt
@@ -6,7 +6,13 @@ import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
 class CheckCurrentUserUseCase @Inject constructor(
-    private val repository: LoginRepository
+    private val repository: LoginRepository,
+    private val updateUserMessageTokenUseCase: UpdateUserMessageTokenUseCase
 ) {
-    operator fun invoke(uid: String): Flow<LoginResult> = repository.checkCurrentUser(uid)
+    suspend operator fun invoke(uid: String, shouldUpdateMessageToken: Boolean = false): Flow<LoginResult> {
+        if (shouldUpdateMessageToken) {
+            updateUserMessageTokenUseCase(uid)
+        }
+        return repository.checkCurrentUser(uid)
+    }
 }

--- a/domain/src/main/java/com/gta/domain/usecase/login/UpdateUserMessageTokenUseCase.kt
+++ b/domain/src/main/java/com/gta/domain/usecase/login/UpdateUserMessageTokenUseCase.kt
@@ -1,0 +1,8 @@
+package com.gta.domain.usecase.login
+
+import com.gta.domain.repository.LoginRepository
+import javax.inject.Inject
+
+class UpdateUserMessageTokenUseCase @Inject constructor(private val loginRepository: LoginRepository) {
+    suspend operator fun invoke(uid: String): Boolean = loginRepository.updateUserMessageToken(uid)
+}

--- a/presentation/src/main/java/com/gta/presentation/ui/login/LoginViewModel.kt
+++ b/presentation/src/main/java/com/gta/presentation/ui/login/LoginViewModel.kt
@@ -34,18 +34,18 @@ class LoginViewModel @Inject constructor(
         val credential = GoogleAuthProvider.getCredential(token, null)
         auth.signInWithCredential(credential).addOnCompleteListener { task ->
             if (task.isSuccessful) {
-                checkCurrentUser()
+                checkCurrentUser(shouldUpdateMessageToken = true)
             } else {
                 Timber.e(task.exception)
             }
         }
     }
 
-    fun checkCurrentUser() {
+    fun checkCurrentUser(shouldUpdateMessageToken: Boolean = false) {
         val user = auth.currentUser ?: return
         FirebaseUtil.setUid(user)
         viewModelScope.launch {
-            _loginEvent.emit(checkCurrentUserUseCase(FirebaseUtil.uid).first())
+            _loginEvent.emit(checkCurrentUserUseCase(FirebaseUtil.uid, shouldUpdateMessageToken).first())
         }
     }
 


### PR DESCRIPTION
## 개요
앱 데이터 삭제시 사용자의 FCM 토큰이 재발급되어 DB 업데이트가 필요하다.

## 작업사항
- Firestore users 콜랙선의 자신의 도큐먼트 messageToken 필드 업데이트
- 구글 로그인 버튼을 통해 checkCurrentUser에 진입할때 FCM 토큰 업데이트


## 변경된 부분
- LoginViewModel `signInWithCredential()`, `checkCurrentUser()` 
- UserDataSource, LoginRepository, CheckCurrentUserUseCase

  CheckCurrentUserUseCase 에서 UpdateUserMessageTokenUseCase 호출

## 실행 화면

https://user-images.githubusercontent.com/54929665/204460711-25dce422-6a7e-43e6-b397-2b58ba94bd7e.mov

## 특이사항
- User 정보가 있는지 확인하는 유즈케이스 (CheckCurrentUserUseCase) 와 토큰 업데이트 하는 유즈케이스 (UpdateUserMessageTokenUseCase) 가 결이 다른거 같아 유즈케이스 안에서 유즈케이스 호출 하는 방식으로 하였어요. (유즈케 까지 안만들고 레포 호출 가능)

- 점점 어느 레포에 넣어야될지가 애매해지고 있어요.. 리팩토링 떄 정리해야될 거 같습니다..

- 이슈 **100 번째**는 나야나
