### PR TITLE
Feature: #97 채팅방 생성, 유저 프로필 변경 감시

### DIFF
--- a/buildSrc/src/main/java/com/gta/buildsrc/Dependencies.kt
+++ b/buildSrc/src/main/java/com/gta/buildsrc/Dependencies.kt
@@ -189,6 +189,9 @@ object Dependencies {
         const val STREAM_CHAT =
             "io.getstream:stream-chat-android-ui-components:${Versions.STREAM_CHAT}"
 
+        const val STREAM_PUSH_PROVIDER =
+            "io.getstream:stream-chat-android-pushprovider-firebase:${Versions.STREAM_CHAT}"
+
         const val TIMBER = "com.jakewharton.timber:timber:${Versions.TIMBER}"
 
         const val INJECT = "javax.inject:javax.inject:${Versions.INJECT}"
@@ -251,6 +254,7 @@ object Dependencies {
             add(Hilt.HILT)
             add(NAVER_MAP)
             add(STREAM_CHAT)
+            add(STREAM_PUSH_PROVIDER)
             add(TIMBER)
             add(AndroidX.SPLASH)
             add(INDICATOR)

--- a/presentation/src/main/java/com/gta/presentation/di/StreamModule.kt
+++ b/presentation/src/main/java/com/gta/presentation/di/StreamModule.kt
@@ -9,13 +9,22 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.logger.ChatLogLevel
+import io.getstream.chat.android.client.notifications.handler.NotificationConfig
 import io.getstream.chat.android.offline.plugin.configuration.Config
 import io.getstream.chat.android.offline.plugin.factory.StreamOfflinePluginFactory
+import io.getstream.chat.android.pushprovider.firebase.FirebasePushDeviceGenerator
 import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
 object StreamModule {
+
+    @Singleton
+    @Provides
+    fun provideNotificationConfig(): NotificationConfig = NotificationConfig(
+        pushDeviceGenerators = listOf(FirebasePushDeviceGenerator()),
+        pushNotificationsEnabled = true
+    )
 
     @Singleton
     @Provides
@@ -29,9 +38,11 @@ object StreamModule {
     @Provides
     fun provideChatClient(
         @ApplicationContext context: Context,
-        offlinePluginFactory: StreamOfflinePluginFactory
+        offlinePluginFactory: StreamOfflinePluginFactory,
+        notificationConfig: NotificationConfig
     ): ChatClient = ChatClient.Builder(STREAM_KEY, context)
         .withPlugin(offlinePluginFactory)
+        .notifications(notificationConfig)
         .logLevel(ChatLogLevel.ALL)
         .build()
 }

--- a/presentation/src/main/java/com/gta/presentation/ui/MainActivity.kt
+++ b/presentation/src/main/java/com/gta/presentation/ui/MainActivity.kt
@@ -4,9 +4,6 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import androidx.activity.viewModels
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.ui.AppBarConfiguration
 import androidx.navigation.ui.navigateUp
@@ -17,10 +14,10 @@ import com.gta.presentation.databinding.ActivityMainBinding
 import com.gta.presentation.secret.NAVER_MAP_CLIENT_ID
 import com.gta.presentation.ui.base.BaseActivity
 import com.gta.presentation.ui.login.LoginActivity
+import com.gta.presentation.util.repeatOnStarted
 import com.naver.maps.map.NaverMapSdk
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class MainActivity : BaseActivity<ActivityMainBinding>(ActivityMainBinding::inflate) {
@@ -41,12 +38,10 @@ class MainActivity : BaseActivity<ActivityMainBinding>(ActivityMainBinding::infl
     }
 
     private fun initCollector() {
-        lifecycleScope.launch {
-            repeatOnLifecycle(Lifecycle.State.STARTED) {
-                viewModel.changeAuthStateEvent.collectLatest { state ->
-                    if (state) {
-                        startLoginActivity()
-                    }
+        repeatOnStarted {
+            viewModel.changeAuthStateEvent.collectLatest { state ->
+                if (state) {
+                    startLoginActivity()
                 }
             }
         }

--- a/presentation/src/main/java/com/gta/presentation/ui/MainActivity.kt
+++ b/presentation/src/main/java/com/gta/presentation/ui/MainActivity.kt
@@ -38,7 +38,7 @@ class MainActivity : BaseActivity<ActivityMainBinding>(ActivityMainBinding::infl
     }
 
     private fun initCollector() {
-        repeatOnStarted {
+        repeatOnStarted(this) {
             viewModel.changeAuthStateEvent.collectLatest { state ->
                 if (state) {
                     startLoginActivity()

--- a/presentation/src/main/java/com/gta/presentation/ui/MainViewModel.kt
+++ b/presentation/src/main/java/com/gta/presentation/ui/MainViewModel.kt
@@ -1,0 +1,36 @@
+package com.gta.presentation.ui
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.google.firebase.auth.FirebaseAuth
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class MainViewModel @Inject constructor(
+    private val auth: FirebaseAuth
+) : ViewModel() {
+
+    private val _changeAuthStateEvent = MutableSharedFlow<Boolean>()
+    val changeAuthStateEvent: SharedFlow<Boolean> get() = _changeAuthStateEvent
+
+    private val authStateListener by lazy {
+        FirebaseAuth.AuthStateListener {
+            viewModelScope.launch {
+                _changeAuthStateEvent.emit(it.currentUser == null)
+            }
+        }
+    }
+
+    init {
+        auth.addAuthStateListener(authStateListener)
+    }
+
+    override fun onCleared() {
+        auth.removeAuthStateListener(authStateListener)
+        super.onCleared()
+    }
+}

--- a/presentation/src/main/java/com/gta/presentation/ui/cardetail/CarDetailViewModel.kt
+++ b/presentation/src/main/java/com/gta/presentation/ui/cardetail/CarDetailViewModel.kt
@@ -81,6 +81,8 @@ class CarDetailViewModel @Inject constructor(
             extraData = emptyMap()
         ).enqueue() { result ->
             if (result.isSuccess) {
+                val str = result.data().members.joinToString("\n")
+                Timber.tag("chatting").i(str)
                 viewModelScope.launch {
                     _navigateChattingEvent.emit(result.data().cid)
                 }

--- a/presentation/src/main/java/com/gta/presentation/ui/cardetail/CarDetailViewModel.kt
+++ b/presentation/src/main/java/com/gta/presentation/ui/cardetail/CarDetailViewModel.kt
@@ -9,9 +9,14 @@ import com.gta.domain.usecase.cardetail.GetUseStateAboutCarUseCase
 import com.gta.domain.usecase.cardetail.UseState
 import com.gta.presentation.util.FirebaseUtil
 import dagger.hilt.android.lifecycle.HiltViewModel
+import io.getstream.chat.android.client.ChatClient
+import io.getstream.chat.android.client.api.models.QueryChannelRequest
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
 import timber.log.Timber
 import javax.inject.Inject
 
@@ -19,15 +24,19 @@ import javax.inject.Inject
 class CarDetailViewModel @Inject constructor(
     args: SavedStateHandle,
     getCarDetailDataUseCase: GetCarDetailDataUseCase,
-    getUseStateAboutCarUseCase: GetUseStateAboutCarUseCase
+    getUseStateAboutCarUseCase: GetUseStateAboutCarUseCase,
+    private val chatClient: ChatClient
 ) : ViewModel() {
 
     val carInfo: StateFlow<CarDetail>
     val useState: StateFlow<UseState>
 
+    private val carId = args.get<String>("CAR_ID") ?: "정보 없음"
+
+    private val _navigateChattingEvent = MutableSharedFlow<String>()
+    val navigateChattingEvent: SharedFlow<String> get() = _navigateChattingEvent
+
     init {
-        val carId = args.get<String>("CAR_ID") ?: "정보 없음"
-        val uid = FirebaseUtil.uid
 
         carInfo = getCarDetailDataUseCase(carId).stateIn(
             scope = viewModelScope,
@@ -35,11 +44,50 @@ class CarDetailViewModel @Inject constructor(
             initialValue = CarDetail()
         )
 
-        useState = getUseStateAboutCarUseCase(uid, carId).stateIn(
+        useState = getUseStateAboutCarUseCase(FirebaseUtil.uid, carId).stateIn(
             scope = viewModelScope,
             started = SharingStarted.WhileSubscribed(5000),
             initialValue = UseState.UNAVAILABLE
         )
+    }
+
+    fun onChattingClick() {
+        if (carId == "정보 없음" || useState.value == UseState.OWNER) return
+        val cid = "${FirebaseUtil.uid}-$carId"
+        checkChatChannel(cid)
+    }
+
+    private fun checkChatChannel(cid: String) {
+        chatClient.queryChannel(
+            "messaging",
+            cid,
+            QueryChannelRequest()
+        ).enqueue { result ->
+            if (result.isSuccess) {
+                viewModelScope.launch {
+                    _navigateChattingEvent.emit(result.data().cid)
+                }
+            } else {
+                createChatChannel(cid)
+            }
+        }
+    }
+
+    private fun createChatChannel(cid: String) {
+        chatClient.createChannel(
+            channelType = "messaging",
+            channelId = cid,
+            memberIds = listOf(FirebaseUtil.uid, carInfo.value.owner.id),
+            extraData = emptyMap()
+        ).enqueue() { result ->
+            if (result.isSuccess) {
+                viewModelScope.launch {
+                    _navigateChattingEvent.emit(result.data().cid)
+                }
+            } else {
+                Timber.tag("chatting").i(result.error().message)
+            }
+        }
     }
 
     fun onReportClick() {

--- a/presentation/src/main/java/com/gta/presentation/ui/chatting/chat/ChattingViewModel.kt
+++ b/presentation/src/main/java/com/gta/presentation/ui/chatting/chat/ChattingViewModel.kt
@@ -6,7 +6,9 @@ import androidx.lifecycle.viewModelScope
 import com.gta.domain.model.SimpleCar
 import com.gta.domain.usecase.car.GetSimpleCarUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -21,13 +23,23 @@ class ChattingViewModel @Inject constructor(
     private val _car = MutableStateFlow(SimpleCar())
     val car: StateFlow<SimpleCar> get() = _car
 
+    private val _navigateCarDetailEvent = MutableSharedFlow<String>()
+    val navigateCarDetailEvent: SharedFlow<String> get() = _navigateCarDetailEvent
+
+    private val carId = args.get<String>("cid")?.substringAfterLast("-") ?: ""
+
     init {
         // cid는 "ChannelType:ChannelId"이 저장되어 있어요
         // ChannelId를 "대여자uid-차id"로 설정해줬기 때문에 ChannelId를 이용해 채팅 화면 상단에 차 정보를 보여줄 수 있습니다.
-        val channelId = args.get<String>("cid") ?: ""
-        val carId = channelId.substringAfterLast("-")
         viewModelScope.launch {
             _car.emit(getSimpleCarUseCase(carId).first())
+        }
+    }
+
+    fun navigateCarDetail() {
+        if (carId.isEmpty()) return
+        viewModelScope.launch {
+            _navigateCarDetailEvent.emit(carId)
         }
     }
 }

--- a/presentation/src/main/java/com/gta/presentation/ui/chatting/list/ChattingListFragment.kt
+++ b/presentation/src/main/java/com/gta/presentation/ui/chatting/list/ChattingListFragment.kt
@@ -7,15 +7,11 @@ import androidx.navigation.fragment.findNavController
 import com.gta.presentation.R
 import com.gta.presentation.databinding.FragmentChattingListBinding
 import com.gta.presentation.ui.base.BaseFragment
-import com.gta.presentation.util.FirebaseUtil
 import dagger.hilt.android.AndroidEntryPoint
 import io.getstream.chat.android.client.ChatClient
-import io.getstream.chat.android.client.api.models.QueryChannelRequest
-import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.ui.channel.list.viewmodel.ChannelListViewModel
 import io.getstream.chat.android.ui.channel.list.viewmodel.bindView
 import io.getstream.chat.android.ui.channel.list.viewmodel.factory.ChannelListViewModelFactory
-import timber.log.Timber
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -30,38 +26,9 @@ class ChattingListFragment : BaseFragment<FragmentChattingListBinding>(
         ChannelListViewModelFactory()
     }
 
-    /*
-     name과 image는 유저의 닉네임과 썸네일이에요
-     하지만 현재 상황에서는 쿼리를 통해서 name, image를 가져와야 하므로 User객체를 즉시 초기화 할 수 없어요
-     그렇기 때문이 일단 고정값으로만 설정해뒀어요
-     사용자의 UserInfo를 지속적으로 감시하면서 UserProfile 객체를 메모리에 저장 해놓는 작업이 필요해요
-    */
-    private val user by lazy {
-        User(
-            id = FirebaseUtil.uid,
-            name = "이동훈",
-            image = "https://firebasestorage.googleapis.com/v0/b/boostcamp-ucmc.appspot.com/o/thumb%2F1669079674202667835770?alt=media&token=25c8ec38-32c8-4bd8-aad1-58e26e0c1b61"
-        )
-    }
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        // 유저를 연결하기 위해선 User객체와 token이 필요해요
-        // Stream의 토큰은 기본적으로 무기한이기 때문에 만료걱정을 안해도 돼요
-        // 성공적으로 연결됐다면 채팅리스트 뷰모델에 채팅리스트 뷰를 바인딩 해줘요
-        // 뷰가 바인딩 되면 내가 속해 있는 채팅 목록을 확인할 수 있어요
-        chatClient.connectUser(
-            user = user,
-            token = chatClient.devToken(user.id)
-        ).enqueue { result ->
-            if (result.isSuccess) {
-                channelListViewModel.bindView(binding.clChattingList, viewLifecycleOwner)
-            } else {
-                Timber.tag("chatting").i(result.error().message)
-            }
-        }
-        // 채팅방이 선택 됐을 때 호출되는 리쓰너에요
-        // 해당 채팅방의 id를 들고 채팅 화면으로 넘어갑니다.
+        channelListViewModel.bindView(binding.clChattingList, viewLifecycleOwner)
         binding.clChattingList.setChannelItemClickListener { channel ->
             findNavController().navigate(
                 ChattingListFragmentDirections.actionChattingListFragmentToChattingFragment(channel.cid)
@@ -73,7 +40,7 @@ class ChattingListFragment : BaseFragment<FragmentChattingListBinding>(
     // 이 화면에서는 필요하지 않지만 예약 완료 화면에서 이 메쏘드를 참고해 채팅방을 생성해야 하기 때문에 냅뒀어요
     // channelId는 대여자uid-차id 에요
     // 채널을 만들기 전에 중복 확인을 위한 queryChannel을 먼저 돌릴 필요가 있어요
-    private fun createChannel() {
+/*    private fun createChannel() {
         chatClient.createChannel(
             channelType = "messaging",
             channelId = "${user.id}-차id",
@@ -84,11 +51,11 @@ class ChattingListFragment : BaseFragment<FragmentChattingListBinding>(
                 Timber.tag("chatting").i(result.error().message)
             }
         }
-    }
+    }*/
 
     // 채널을 만들기 전에 중복 확인을 위한 queryChannel을 먼저 돌릴 필요가 있어요
     // 이미 채팅방이 있다면 만들어선 안되겠죠..?!
-    private fun checkChannel() {
+/*    private fun checkChannel() {
         chatClient.queryChannel(
             "messaging",
             "${user.id}-차id",
@@ -104,5 +71,5 @@ class ChattingListFragment : BaseFragment<FragmentChattingListBinding>(
                 Timber.tag("chatting").i(result.error().message)
             }
         }
-    }
+    }*/
 }

--- a/presentation/src/main/java/com/gta/presentation/ui/chatting/list/ChattingListFragment.kt
+++ b/presentation/src/main/java/com/gta/presentation/ui/chatting/list/ChattingListFragment.kt
@@ -35,41 +35,4 @@ class ChattingListFragment : BaseFragment<FragmentChattingListBinding>(
             )
         }
     }
-
-    // 채팅 채널을 만드는 메쏘드에요
-    // 이 화면에서는 필요하지 않지만 예약 완료 화면에서 이 메쏘드를 참고해 채팅방을 생성해야 하기 때문에 냅뒀어요
-    // channelId는 대여자uid-차id 에요
-    // 채널을 만들기 전에 중복 확인을 위한 queryChannel을 먼저 돌릴 필요가 있어요
-/*    private fun createChannel() {
-        chatClient.createChannel(
-            channelType = "messaging",
-            channelId = "${user.id}-차id",
-            memberIds = listOf(user.id, "상대방uid"),
-            extraData = emptyMap()
-        ).enqueue() { result ->
-            if (result.isError) {
-                Timber.tag("chatting").i(result.error().message)
-            }
-        }
-    }*/
-
-    // 채널을 만들기 전에 중복 확인을 위한 queryChannel을 먼저 돌릴 필요가 있어요
-    // 이미 채팅방이 있다면 만들어선 안되겠죠..?!
-/*    private fun checkChannel() {
-        chatClient.queryChannel(
-            "messaging",
-            "${user.id}-차id",
-            QueryChannelRequest()
-        ).enqueue { result ->
-            if (result.isSuccess) {
-                // 쿼리에 성공했다면 채널id를 받을 수 있어요
-                // 이 채널id를 들고 채팅 화면으로 넘어가면 돼요
-                Timber.tag("chatting").i(result.data().cid)
-            } else {
-                // 채널이 없다면 여기로 와요
-                // 이럴 땐 쿼리에 쓴 채널Id로 새로운 채널을 만들어 봐요
-                Timber.tag("chatting").i(result.error().message)
-            }
-        }
-    }*/
 }

--- a/presentation/src/main/java/com/gta/presentation/ui/chatting/list/ChattingListFragment.kt
+++ b/presentation/src/main/java/com/gta/presentation/ui/chatting/list/ChattingListFragment.kt
@@ -22,17 +22,20 @@ class ChattingListFragment : BaseFragment<FragmentChattingListBinding>(
     @Inject
     lateinit var chatClient: ChatClient
 
-    private val channelListViewModel: ChannelListViewModel by viewModels {
-        ChannelListViewModelFactory()
-    }
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        val channelListViewModel: ChannelListViewModel by viewModels {
+            ChannelListViewModelFactory()
+        }
         channelListViewModel.bindView(binding.clChattingList, viewLifecycleOwner)
         binding.clChattingList.setChannelItemClickListener { channel ->
             findNavController().navigate(
                 ChattingListFragmentDirections.actionChattingListFragmentToChattingFragment(channel.cid)
             )
+        }
+        binding.clChattingList.setChannelLongClickListener { channel ->
+            chatClient.deleteChannel(channel.type, channel.id).enqueue()
+            true
         }
     }
 }

--- a/presentation/src/main/java/com/gta/presentation/ui/login/LoginActivity.kt
+++ b/presentation/src/main/java/com/gta/presentation/ui/login/LoginActivity.kt
@@ -9,9 +9,6 @@ import android.widget.FrameLayout
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.repeatOnLifecycle
 import com.google.android.gms.auth.api.Auth
 import com.google.android.gms.auth.api.signin.GoogleSignInClient
 import com.google.android.material.bottomsheet.BottomSheetBehavior
@@ -19,9 +16,9 @@ import com.gta.domain.model.LoginResult
 import com.gta.presentation.databinding.ActivityLoginBinding
 import com.gta.presentation.ui.MainActivity
 import com.gta.presentation.ui.base.BaseActivity
+import com.gta.presentation.util.repeatOnStarted
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.launch
 import java.io.BufferedReader
 import java.io.IOException
 import java.io.InputStreamReader
@@ -62,15 +59,13 @@ class LoginActivity : BaseActivity<ActivityLoginBinding>(ActivityLoginBinding::i
     }
 
     private fun initCollector() {
-        lifecycleScope.launch {
-            repeatOnLifecycle(Lifecycle.State.STARTED) {
-                viewModel.loginEvent.collectLatest { state ->
-                    when (state) {
-                        LoginResult.SUCCESS -> startMainActivity()
-                        LoginResult.FAILURE -> {}
-                        LoginResult.NEWUSER -> {
-                            bottomSheetBehavior.state = BottomSheetBehavior.STATE_EXPANDED
-                        }
+        repeatOnStarted {
+            viewModel.loginEvent.collectLatest { state ->
+                when (state) {
+                    LoginResult.SUCCESS -> startMainActivity()
+                    LoginResult.FAILURE -> {}
+                    LoginResult.NEWUSER -> {
+                        bottomSheetBehavior.state = BottomSheetBehavior.STATE_EXPANDED
                     }
                 }
             }

--- a/presentation/src/main/java/com/gta/presentation/ui/login/LoginActivity.kt
+++ b/presentation/src/main/java/com/gta/presentation/ui/login/LoginActivity.kt
@@ -59,7 +59,7 @@ class LoginActivity : BaseActivity<ActivityLoginBinding>(ActivityLoginBinding::i
     }
 
     private fun initCollector() {
-        repeatOnStarted {
+        repeatOnStarted(this) {
             viewModel.loginEvent.collectLatest { state ->
                 when (state) {
                     LoginResult.SUCCESS -> startMainActivity()

--- a/presentation/src/main/java/com/gta/presentation/ui/login/LoginActivity.kt
+++ b/presentation/src/main/java/com/gta/presentation/ui/login/LoginActivity.kt
@@ -24,7 +24,6 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import java.io.BufferedReader
 import java.io.IOException
-import java.io.InputStream
 import java.io.InputStreamReader
 import javax.inject.Inject
 
@@ -74,12 +73,6 @@ class LoginActivity : BaseActivity<ActivityLoginBinding>(ActivityLoginBinding::i
                         }
                     }
                 }
-
-                viewModel.termsEvent.collectLatest { result ->
-                    if (result) {
-                        startMainActivity()
-                    }
-                }
             }
         }
     }
@@ -109,11 +102,9 @@ class LoginActivity : BaseActivity<ActivityLoginBinding>(ActivityLoginBinding::i
         binding.btnAccept.setOnClickListener {
             bottomSheetBehavior.state = BottomSheetBehavior.STATE_HIDDEN
             viewModel.signUp()
-            viewModel.checkTermsAccepted(true)
         }
         binding.btnCancel.setOnClickListener {
             bottomSheetBehavior.state = BottomSheetBehavior.STATE_HIDDEN
-            viewModel.checkTermsAccepted(false)
         }
     }
 
@@ -128,17 +119,15 @@ class LoginActivity : BaseActivity<ActivityLoginBinding>(ActivityLoginBinding::i
     }
 
     private fun getAssetData(fileName: String): String {
-        val inputStream: InputStream?
         var result: String
         try {
-            inputStream = resources.assets.open(fileName, AssetManager.ACCESS_BUFFER)
+            val inputStream = resources.assets.open(fileName, AssetManager.ACCESS_BUFFER)
             val reader = BufferedReader(InputStreamReader(inputStream))
             result = reader.readLines().joinToString("\n")
             inputStream.close()
         } catch (e: IOException) {
             result = ""
         }
-
         return result
     }
 }

--- a/presentation/src/main/java/com/gta/presentation/ui/login/LoginViewModel.kt
+++ b/presentation/src/main/java/com/gta/presentation/ui/login/LoginViewModel.kt
@@ -7,8 +7,11 @@ import com.google.firebase.auth.GoogleAuthProvider
 import com.gta.domain.model.LoginResult
 import com.gta.domain.usecase.login.CheckCurrentUserUseCase
 import com.gta.domain.usecase.login.SignUpUseCase
+import com.gta.domain.usecase.user.GetUserProfileUseCase
 import com.gta.presentation.util.FirebaseUtil
 import dagger.hilt.android.lifecycle.HiltViewModel
+import io.getstream.chat.android.client.ChatClient
+import io.getstream.chat.android.client.models.User
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.first
@@ -19,15 +22,14 @@ import javax.inject.Inject
 @HiltViewModel
 class LoginViewModel @Inject constructor(
     private val auth: FirebaseAuth,
+    private val chatClient: ChatClient,
+    private val getUserProfileUseCase: GetUserProfileUseCase,
     private val checkCurrentUserUseCase: CheckCurrentUserUseCase,
     private val signUpUseCase: SignUpUseCase
 ) : ViewModel() {
 
     private val _loginEvent = MutableSharedFlow<LoginResult>()
     val loginEvent: SharedFlow<LoginResult> get() = _loginEvent
-
-    private val _termsEvent = MutableSharedFlow<Boolean>()
-    val termsEvent: SharedFlow<Boolean> get() = _termsEvent
 
     fun signInWithToken(token: String?) {
         token ?: return
@@ -45,19 +47,43 @@ class LoginViewModel @Inject constructor(
         val user = auth.currentUser ?: return
         FirebaseUtil.setUid(user)
         viewModelScope.launch {
-            _loginEvent.emit(checkCurrentUserUseCase(FirebaseUtil.uid).first())
+            handleLoginResult(checkCurrentUserUseCase(FirebaseUtil.uid).first())
         }
     }
 
     fun signUp() {
         viewModelScope.launch {
-            _loginEvent.emit(signUpUseCase(FirebaseUtil.uid).first())
+            handleLoginResult(signUpUseCase(FirebaseUtil.uid).first())
         }
     }
 
-    fun checkTermsAccepted(value: Boolean) {
+    private fun handleLoginResult(loginResult: LoginResult) {
         viewModelScope.launch {
-            _termsEvent.emit(value)
+            if (loginResult == LoginResult.SUCCESS) {
+                createChatUser()
+            } else {
+                _loginEvent.emit(loginResult)
+            }
+        }
+    }
+
+    private fun createChatUser() {
+        viewModelScope.launch {
+            val profile = getUserProfileUseCase(FirebaseUtil.uid).first()
+            val user = User(
+                id = FirebaseUtil.uid,
+                name = profile.name,
+                image = profile.image
+            )
+            chatClient.connectUser(
+                user = user,
+                token = chatClient.devToken(user.id)
+            ).enqueue { result ->
+                val loginResult = if (result.isSuccess) LoginResult.SUCCESS else LoginResult.FAILURE
+                viewModelScope.launch {
+                    _loginEvent.emit(loginResult)
+                }
+            }
         }
     }
 }

--- a/presentation/src/main/java/com/gta/presentation/ui/map/MapFragment.kt
+++ b/presentation/src/main/java/com/gta/presentation/ui/map/MapFragment.kt
@@ -35,7 +35,6 @@ import com.naver.maps.map.util.MarkerIcons
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
-import timber.log.Timber
 
 @AndroidEntryPoint
 class MapFragment : BaseFragment<FragmentMapBinding>(R.layout.fragment_map), OnMapReadyCallback {

--- a/presentation/src/main/java/com/gta/presentation/ui/map/MapViewModel.kt
+++ b/presentation/src/main/java/com/gta/presentation/ui/map/MapViewModel.kt
@@ -32,8 +32,7 @@ import javax.inject.Inject
 class MapViewModel @Inject constructor(
     private val getNearCarsUseCase: GetNearCarsUseCase,
     private val searchAddressUseCase: GetSearchAddressUseCase
-) :
-    ViewModel() {
+) : ViewModel() {
     private val SEARCH_TIMEOUT = 500L
 
     private var _carsRequest = MutableSharedFlow<Pair<Coordinate, Coordinate>>(

--- a/presentation/src/main/java/com/gta/presentation/ui/nickname/NicknameFragment.kt
+++ b/presentation/src/main/java/com/gta/presentation/ui/nickname/NicknameFragment.kt
@@ -3,18 +3,15 @@ package com.gta.presentation.ui.nickname
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.fragment.findNavController
 import com.gta.domain.model.NicknameState
 import com.gta.presentation.R
 import com.gta.presentation.databinding.FragmentNicknameBinding
 import com.gta.presentation.ui.MainActivity
 import com.gta.presentation.ui.base.BaseFragment
+import com.gta.presentation.util.repeatOnStarted
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class NicknameFragment : BaseFragment<FragmentNicknameBinding>(
@@ -31,19 +28,15 @@ class NicknameFragment : BaseFragment<FragmentNicknameBinding>(
     }
 
     private fun initCollector() {
-        lifecycleScope.launch {
-            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                viewModel.nicknameState.collectLatest { state ->
-                    handleNicknameState(state)
-                }
+        repeatOnStarted {
+            viewModel.nicknameState.collectLatest { state ->
+                handleNicknameState(state)
             }
         }
-        lifecycleScope.launch {
-            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                viewModel.nicknameChangeEvent.collectLatest { state ->
-                    if (state) {
-                        findNavController().navigate(R.id.action_nicknameFragment_to_myPageFragment)
-                    }
+        repeatOnStarted {
+            viewModel.nicknameChangeEvent.collectLatest { state ->
+                if (state) {
+                    findNavController().navigate(R.id.action_nicknameFragment_to_myPageFragment)
                 }
             }
         }

--- a/presentation/src/main/java/com/gta/presentation/ui/nickname/NicknameFragment.kt
+++ b/presentation/src/main/java/com/gta/presentation/ui/nickname/NicknameFragment.kt
@@ -28,12 +28,12 @@ class NicknameFragment : BaseFragment<FragmentNicknameBinding>(
     }
 
     private fun initCollector() {
-        repeatOnStarted {
+        repeatOnStarted(viewLifecycleOwner) {
             viewModel.nicknameState.collectLatest { state ->
                 handleNicknameState(state)
             }
         }
-        repeatOnStarted {
+        repeatOnStarted(viewLifecycleOwner) {
             viewModel.nicknameChangeEvent.collectLatest { state ->
                 if (state) {
                     findNavController().navigate(R.id.action_nicknameFragment_to_myPageFragment)

--- a/presentation/src/main/java/com/gta/presentation/util/RepeatOnStarted.kt
+++ b/presentation/src/main/java/com/gta/presentation/util/RepeatOnStarted.kt
@@ -7,8 +7,8 @@ import androidx.lifecycle.repeatOnLifecycle
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
-fun LifecycleOwner.repeatOnStarted(block: suspend CoroutineScope.() -> Unit) {
+fun LifecycleOwner.repeatOnStarted(lifecycleOwner: LifecycleOwner, block: suspend CoroutineScope.() -> Unit) {
     lifecycleScope.launch {
-        lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED, block)
+        lifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED, block)
     }
 }

--- a/presentation/src/main/java/com/gta/presentation/util/repeatOnStarted.kt
+++ b/presentation/src/main/java/com/gta/presentation/util/repeatOnStarted.kt
@@ -1,0 +1,14 @@
+package com.gta.presentation.util
+
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+fun LifecycleOwner.repeatOnStarted(block: suspend CoroutineScope.() -> Unit) {
+    lifecycleScope.launch {
+        lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED, block)
+    }
+}

--- a/presentation/src/main/res/layout/fragment_car_detail.xml
+++ b/presentation/src/main/res/layout/fragment_car_detail.xml
@@ -176,6 +176,7 @@
                     app:layout_constraintTop_toBottomOf="@+id/tv_owner_label">
 
                     <include
+                        android:id="@+id/in_owner_profile"
                         layout="@layout/include_owner_profile"
                         bind:owner="@{vm.carInfo.owner}" />
 

--- a/presentation/src/main/res/layout/fragment_map.xml
+++ b/presentation/src/main/res/layout/fragment_map.xml
@@ -92,7 +92,6 @@
                     android:layout_width="0dp"
                     android:layout_height="match_parent"
                     app:image_uri="@{vm.selectCar.image}"
-                    app:tint="@color/neutral80"
                     app:layout_constraintDimensionRatio="H,1:1"
                     app:layout_constraintTop_toTopOf="parent"
                     app:layout_constraintStart_toStartOf="parent"/>

--- a/presentation/src/main/res/layout/item_mypage_carlist.xml
+++ b/presentation/src/main/res/layout/item_mypage_carlist.xml
@@ -19,6 +19,7 @@
             android:id="@+id/iv_car"
             android:layout_width="100dp"
             android:layout_height="100dp"
+            app:image_uri="@{data.image}"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:srcCompat="@drawable/ic_logo"

--- a/presentation/src/main/res/navigation/nav_main.xml
+++ b/presentation/src/main/res/navigation/nav_main.xml
@@ -81,6 +81,9 @@
         <action
             android:id="@+id/action_carDetailFragment_to_reservationFragment"
             app:destination="@id/reservationFragment" />
+        <action
+            android:id="@+id/action_carDetailFragment_to_chattingFragment"
+            app:destination="@id/chattingFragment" />
     </fragment>
 
     <fragment

--- a/presentation/src/main/res/navigation/nav_main.xml
+++ b/presentation/src/main/res/navigation/nav_main.xml
@@ -27,6 +27,9 @@
             android:name="cid"
             app:argType="string"
             android:defaultValue="" />
+        <action
+            android:id="@+id/action_chattingFragment_to_carDetailFragment"
+            app:destination="@id/carDetailFragment" />
     </fragment>
 
     <fragment


### PR DESCRIPTION
## 개요
- 채팅방 생성, 유저 프로필 변경 감시

## 작업사항
- 상세 화면에서 채팅방 생성 기능 추가
- 로그인 화면에서 채팅 유저 연결 및 닉네임, 썸네일 변경 시 채팅 유저 업데이트
- 채팅 화면에서 상단의 자동차 요약 정보를 터치하면 상세 화면으로 이동
- 채팅 목록 화면에서 롱클릭으로 채팅방을 없앨 수 있습니다.
- 내 차 등록 화면에서 자동차 사진 데이터 바인딩
- 지도 화면 바텀 씨트의 자동차 이미지 뷰 틴트 제거
- repeatOnStarted 확장함수 추가
  - 편리해요

## 변경된 부분
- MainActivity
  - repeatOnStarted 적용 
  - Auth Listener를 ViewModel로 분리
- CarDetailFragment
  - repeatOnStarted 적용 
  - 채팅하기 클릭 이벤트 연결
- CarDetailViewModel
  - 채팅방 생성 동작 추가
- LoginActivity
  - repeatOnStarted 적용 
  - termsEvent 제거
- LoginViewModel
  - 로그인에 성공했으면 ChatClient에 User를 연결하는 동작 추가
  - termsEvent 제거
- MapViewModel
  - 주저앉은 ViewModel()을 위로올림
- MyPageViewModel
  - 채팅 User에 변경된 썸네일 반영하는 동작 추가
- NicknameFragment
  - repeatOnStarted 적용
- NicknameViewModel
  - 채팅 User에 변경된 닉네임 반영하는 동작 추가

## 실행 화면
### 내 차 화면
![내차목록이미지](https://user-images.githubusercontent.com/90435036/204508032-a876b524-ca51-499d-8154-084d18d24346.jpg)

### 차주에게 예약 문의를 하는 씨나리오
![예약문의시나리오](https://user-images.githubusercontent.com/90435036/204508541-2333917d-3b97-47a0-a21f-835df9d7900c.gif)

### 채팅 화면에서 상세 화면으로 이동
![채팅에서상세](https://user-images.githubusercontent.com/90435036/204508572-9be6c9ee-9b81-4926-b09b-f65b34ac1554.gif)

## 특이사항
- 내일은 채팅이 왔을 때 노티를 주는 동작을 만들어보겠읍니다