### PR TITLE
Feature: #106 채팅 노티피케이션 연결, 채팅 목록 드자인

### DIFF
--- a/data/src/main/java/com/gta/data/source/LicenseDataSource.kt
+++ b/data/src/main/java/com/gta/data/source/LicenseDataSource.kt
@@ -25,8 +25,7 @@ class LicenseDataSource @Inject constructor(
                 if (it.isSuccessful) {
                     val userInfo = it.result.toObject(UserInfo::class.java)
                     trySend(userInfo?.license)
-                }
-                else {
+                } else {
                     trySend(null)
                 }
             }

--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
     <uses-permission android:name="android.permission.CAMERA"/>
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application>
         <provider

--- a/presentation/src/main/java/com/gta/presentation/NotificationService.kt
+++ b/presentation/src/main/java/com/gta/presentation/NotificationService.kt
@@ -37,7 +37,7 @@ class NotificationService : FirebaseMessagingService() {
 
     override fun onNewToken(token: String) {
         runCatching {
-            FirebaseMessagingDelegate.registerFirebaseToken(token, "ucmc")
+            FirebaseMessagingDelegate.registerFirebaseToken(token, getString(R.string.chatting_provider_name))
         }
         scope.launch {
             setMessageTokenUseCase(token)

--- a/presentation/src/main/java/com/gta/presentation/NotificationService.kt
+++ b/presentation/src/main/java/com/gta/presentation/NotificationService.kt
@@ -9,6 +9,7 @@ import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 import com.gta.domain.usecase.notification.SetMessageTokenUseCase
 import dagger.hilt.android.AndroidEntryPoint
+import io.getstream.chat.android.pushprovider.firebase.FirebaseMessagingDelegate
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
@@ -22,25 +23,36 @@ class NotificationService : FirebaseMessagingService() {
     private val scope = CoroutineScope(Dispatchers.IO)
 
     private val notificationManager: NotificationManager by lazy {
-        getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        (getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager).apply {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                val channel = NotificationChannel(
+                    getString(R.string.default_notification_channel_id),
+                    getString(R.string.default_notification_name),
+                    NotificationManager.IMPORTANCE_HIGH
+                )
+                createNotificationChannel(channel)
+            }
+        }
     }
 
     override fun onNewToken(token: String) {
+        runCatching {
+            FirebaseMessagingDelegate.registerFirebaseToken(token, "ucmc")
+        }
         scope.launch {
             setMessageTokenUseCase(token)
         }
     }
 
     override fun onMessageReceived(message: RemoteMessage) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            val channel = NotificationChannel(
-                getString(R.string.default_notification_channel_id),
-                getString(R.string.default_notification_name),
-                NotificationManager.IMPORTANCE_HIGH
-            )
-            notificationManager.createNotificationChannel(channel)
+        runCatching {
+            if(FirebaseMessagingDelegate.handleRemoteMessage(message).not()) {
+                handleUCMCMessage(message)
+            }
         }
+    }
 
+    private fun handleUCMCMessage(message: RemoteMessage) {
         val builder = NotificationCompat.Builder(this, getString(R.string.default_notification_channel_id))
             .setSmallIcon(R.drawable.ic_logo)
             .setContentTitle(message.data["type"])

--- a/presentation/src/main/java/com/gta/presentation/NotificationService.kt
+++ b/presentation/src/main/java/com/gta/presentation/NotificationService.kt
@@ -46,7 +46,7 @@ class NotificationService : FirebaseMessagingService() {
 
     override fun onMessageReceived(message: RemoteMessage) {
         runCatching {
-            if(FirebaseMessagingDelegate.handleRemoteMessage(message).not()) {
+            if (FirebaseMessagingDelegate.handleRemoteMessage(message).not()) {
                 handleUCMCMessage(message)
             }
         }

--- a/presentation/src/main/java/com/gta/presentation/di/StreamModule.kt
+++ b/presentation/src/main/java/com/gta/presentation/di/StreamModule.kt
@@ -22,7 +22,7 @@ object StreamModule {
     @Singleton
     @Provides
     fun provideNotificationConfig(): NotificationConfig = NotificationConfig(
-        pushDeviceGenerators = listOf(FirebasePushDeviceGenerator()),
+        pushDeviceGenerators = listOf(FirebasePushDeviceGenerator(providerName = "ucmc")),
         pushNotificationsEnabled = true
     )
 

--- a/presentation/src/main/java/com/gta/presentation/di/StreamModule.kt
+++ b/presentation/src/main/java/com/gta/presentation/di/StreamModule.kt
@@ -24,7 +24,6 @@ import javax.inject.Singleton
 @Module
 @InstallIn(SingletonComponent::class)
 object StreamModule {
-    
     @Singleton
     @Provides
     fun provideNotificationHandler(@ApplicationContext context: Context): NotificationHandler =
@@ -43,7 +42,7 @@ object StreamModule {
                 intents.last()
             }
         )
-    
+
     @Singleton
     @Provides
     fun provideNotificationConfig(): NotificationConfig = NotificationConfig(

--- a/presentation/src/main/java/com/gta/presentation/di/StreamModule.kt
+++ b/presentation/src/main/java/com/gta/presentation/di/StreamModule.kt
@@ -37,7 +37,8 @@ object StreamModule {
                 val intents = NavDeepLinkBuilder(context)
                     .setComponentName(MainActivity::class.java)
                     .setGraph(R.navigation.nav_main)
-                    .setDestination(R.id.chattingFragment, bundle)
+                    .addDestination(R.id.chattingListFragment)
+                    .addDestination(R.id.chattingFragment, bundle)
                     .createTaskStackBuilder().intents
                 intents.last()
             }

--- a/presentation/src/main/java/com/gta/presentation/di/StreamModule.kt
+++ b/presentation/src/main/java/com/gta/presentation/di/StreamModule.kt
@@ -45,8 +45,10 @@ object StreamModule {
 
     @Singleton
     @Provides
-    fun provideNotificationConfig(): NotificationConfig = NotificationConfig(
-        pushDeviceGenerators = listOf(FirebasePushDeviceGenerator(providerName = "ucmc")),
+    fun provideNotificationConfig(@ApplicationContext context: Context): NotificationConfig = NotificationConfig(
+        pushDeviceGenerators = listOf(
+            FirebasePushDeviceGenerator(providerName = context.getString(R.string.chatting_provider_name))
+        ),
         pushNotificationsEnabled = true
     )
 

--- a/presentation/src/main/java/com/gta/presentation/di/StreamModule.kt
+++ b/presentation/src/main/java/com/gta/presentation/di/StreamModule.kt
@@ -37,8 +37,7 @@ object StreamModule {
                 val intents = NavDeepLinkBuilder(context)
                     .setComponentName(MainActivity::class.java)
                     .setGraph(R.navigation.nav_main)
-                    .setDestination(R.id.chattingFragment)
-                    .setArguments(bundle)
+                    .setDestination(R.id.chattingFragment, bundle)
                     .createTaskStackBuilder().intents
                 intents.last()
             }

--- a/presentation/src/main/java/com/gta/presentation/di/StreamModule.kt
+++ b/presentation/src/main/java/com/gta/presentation/di/StreamModule.kt
@@ -1,7 +1,11 @@
 package com.gta.presentation.di
 
 import android.content.Context
+import android.os.Bundle
+import androidx.navigation.NavDeepLinkBuilder
+import com.gta.presentation.R
 import com.gta.presentation.secret.STREAM_KEY
+import com.gta.presentation.ui.MainActivity
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -10,6 +14,8 @@ import dagger.hilt.components.SingletonComponent
 import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.logger.ChatLogLevel
 import io.getstream.chat.android.client.notifications.handler.NotificationConfig
+import io.getstream.chat.android.client.notifications.handler.NotificationHandler
+import io.getstream.chat.android.client.notifications.handler.NotificationHandlerFactory
 import io.getstream.chat.android.offline.plugin.configuration.Config
 import io.getstream.chat.android.offline.plugin.factory.StreamOfflinePluginFactory
 import io.getstream.chat.android.pushprovider.firebase.FirebasePushDeviceGenerator
@@ -18,7 +24,26 @@ import javax.inject.Singleton
 @Module
 @InstallIn(SingletonComponent::class)
 object StreamModule {
-
+    
+    @Singleton
+    @Provides
+    fun provideNotificationHandler(@ApplicationContext context: Context): NotificationHandler =
+        NotificationHandlerFactory.createNotificationHandler(
+            context = context,
+            newMessageIntent = { _, channelType, channelId ->
+                val bundle = Bundle().apply {
+                    putString("cid", "$channelType:$channelId")
+                }
+                val intents = NavDeepLinkBuilder(context)
+                    .setComponentName(MainActivity::class.java)
+                    .setGraph(R.navigation.nav_main)
+                    .setDestination(R.id.chattingFragment)
+                    .setArguments(bundle)
+                    .createTaskStackBuilder().intents
+                intents.last()
+            }
+        )
+    
     @Singleton
     @Provides
     fun provideNotificationConfig(): NotificationConfig = NotificationConfig(
@@ -39,10 +64,11 @@ object StreamModule {
     fun provideChatClient(
         @ApplicationContext context: Context,
         offlinePluginFactory: StreamOfflinePluginFactory,
-        notificationConfig: NotificationConfig
+        notificationConfig: NotificationConfig,
+        notificationHandler: NotificationHandler
     ): ChatClient = ChatClient.Builder(STREAM_KEY, context)
         .withPlugin(offlinePluginFactory)
-        .notifications(notificationConfig)
+        .notifications(notificationConfig, notificationHandler)
         .logLevel(ChatLogLevel.ALL)
         .build()
 }

--- a/presentation/src/main/java/com/gta/presentation/ui/cardetail/CarDetailViewModel.kt
+++ b/presentation/src/main/java/com/gta/presentation/ui/cardetail/CarDetailViewModel.kt
@@ -74,21 +74,19 @@ class CarDetailViewModel @Inject constructor(
     }
 
     private fun createChatChannel(cid: String) {
-        chatClient.createChannel(
+        val result = chatClient.createChannel(
             channelType = "messaging",
             channelId = cid,
             memberIds = listOf(FirebaseUtil.uid, carInfo.value.owner.id),
             extraData = emptyMap()
-        ).enqueue() { result ->
-            if (result.isSuccess) {
-                val str = result.data().members.joinToString("\n")
-                Timber.tag("chatting").i(str)
-                viewModelScope.launch {
-                    _navigateChattingEvent.emit(result.data().cid)
-                }
-            } else {
-                Timber.tag("chatting").i(result.error().message)
+        ).execute()
+
+        if (result.isSuccess) {
+            viewModelScope.launch {
+                _navigateChattingEvent.emit(result.data().cid)
             }
+        } else {
+            Timber.tag("chatting").i(result.error().message)
         }
     }
 

--- a/presentation/src/main/java/com/gta/presentation/ui/chatting/list/ChattingListViewHolder.kt
+++ b/presentation/src/main/java/com/gta/presentation/ui/chatting/list/ChattingListViewHolder.kt
@@ -43,7 +43,7 @@ class ChattingListViewHolder(
         LayoutInflater.from(parent.context),
         parent,
         false
-    ),
+    )
 ) : BaseChannelListItemViewHolder(binding.root) {
 
     private lateinit var channel: Channel

--- a/presentation/src/main/java/com/gta/presentation/ui/chatting/list/ChattingListViewHolder.kt
+++ b/presentation/src/main/java/com/gta/presentation/ui/chatting/list/ChattingListViewHolder.kt
@@ -1,0 +1,75 @@
+package com.gta.presentation.ui.chatting.list
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import com.getstream.sdk.chat.utils.formatDate
+import com.gta.domain.usecase.car.GetSimpleCarUseCase
+import com.gta.presentation.databinding.ItemChattingListBinding
+import io.getstream.chat.android.client.ChatClient
+import io.getstream.chat.android.client.extensions.internal.lastMessage
+import io.getstream.chat.android.client.models.Channel
+import io.getstream.chat.android.core.internal.InternalStreamChatApi
+import io.getstream.chat.android.ui.ChatUI
+import io.getstream.chat.android.ui.channel.list.ChannelListView
+import io.getstream.chat.android.ui.channel.list.adapter.ChannelListPayloadDiff
+import io.getstream.chat.android.ui.channel.list.adapter.viewholder.BaseChannelListItemViewHolder
+import io.getstream.chat.android.ui.channel.list.adapter.viewholder.ChannelListItemViewHolderFactory
+import kotlinx.coroutines.CompletableJob
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+
+class ChattingListItemViewHolderFactory(
+    private val job: CompletableJob,
+    private val getSimpleCarUseCase: GetSimpleCarUseCase
+) : ChannelListItemViewHolderFactory() {
+    override fun createChannelViewHolder(parentView: ViewGroup): BaseChannelListItemViewHolder {
+        return ChattingListViewHolder(
+            parentView,
+            job,
+            getSimpleCarUseCase,
+            listenerContainer.channelClickListener
+        )
+    }
+}
+
+class ChattingListViewHolder(
+    parent: ViewGroup,
+    private val job: CompletableJob,
+    private val getSimpleCarUseCase: GetSimpleCarUseCase,
+    private val channelClickListener: ChannelListView.ChannelClickListener,
+    private val binding: ItemChattingListBinding = ItemChattingListBinding.inflate(
+        LayoutInflater.from(parent.context),
+        parent,
+        false
+    ),
+) : BaseChannelListItemViewHolder(binding.root) {
+
+    private lateinit var channel: Channel
+
+    init {
+        binding.root.setOnClickListener { channelClickListener.onClick(channel) }
+    }
+
+    @OptIn(InternalStreamChatApi::class)
+    override fun bind(channel: Channel, diff: ChannelListPayloadDiff) {
+        this.channel = channel
+        val carId = channel.id.split("-").last()
+        CoroutineScope(Dispatchers.IO + job).launch {
+            binding.carImage = getSimpleCarUseCase(carId).first().image
+        }
+        binding.ivChannelListThumb.setChannelData(channel)
+        binding.tvChannelListName.text = ChatUI.channelNameFormatter.formatChannelName(
+            channel = channel,
+            currentUser = ChatClient.instance().getCurrentUser()
+        )
+        binding.tvChannelListTime.text = ChatUI.dateFormatter.formatDate(channel.lastMessageAt)
+        val message = channel.lastMessage ?: return
+        binding.tvChannelListMessage.text = ChatUI.messagePreviewFormatter.formatMessagePreview(
+            channel = channel,
+            message = message,
+            currentUser = null
+        )
+    }
+}

--- a/presentation/src/main/java/com/gta/presentation/ui/mypage/license/MyPageLicenseViewModel.kt
+++ b/presentation/src/main/java/com/gta/presentation/ui/mypage/license/MyPageLicenseViewModel.kt
@@ -2,7 +2,6 @@ package com.gta.presentation.ui.mypage.license
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.google.firebase.auth.FirebaseAuth
 import com.gta.domain.model.DrivingLicense
 import com.gta.domain.usecase.license.GetLicenseFromDatabaseUseCase
 import com.gta.presentation.util.FirebaseUtil

--- a/presentation/src/main/res/layout/item_chatting_list.xml
+++ b/presentation/src/main/res/layout/item_chatting_list.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+        <variable
+            name="carImage"
+            type="String" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="64dp">
+
+        <io.getstream.chat.android.ui.avatar.AvatarView
+            android:id="@+id/iv_channel_list_thumb"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            style="@style/StreamUi.ChannelList.Item.Avatar"
+            android:layout_marginVertical="@dimen/padding_medium"
+            android:layout_marginStart="@dimen/padding_small"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:src="@tools:sample/avatars" />
+
+        <TextView
+            android:id="@+id/tv_channel_list_name"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:ellipsize="end"
+            android:singleLine="true"
+            android:textAppearance="@style/StreamUiTextAppearance.BodyBold"
+            app:layout_constraintBottom_toTopOf="@id/tv_channel_list_message"
+            app:layout_constraintVertical_chainStyle="spread_inside"
+            app:layout_constraintStart_toEndOf="@id/iv_channel_list_thumb"
+            app:layout_constraintTop_toTopOf="@+id/iv_channel_list_thumb"
+            tools:text="지존동훈" />
+
+        <TextView
+            android:id="@+id/tv_channel_list_time"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/padding_small"
+            android:ellipsize="end"
+            android:singleLine="true"
+            android:textAppearance="@style/StreamUiTextAppearance.Footnote"
+            app:layout_constraintTop_toTopOf="@id/tv_channel_list_name"
+            app:layout_constraintBottom_toBottomOf="@id/tv_channel_list_name"
+            app:layout_constraintStart_toEndOf="@id/tv_channel_list_name"
+            tools:text="방금 전" />
+
+        <TextView
+            android:id="@+id/tv_channel_list_message"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:textAppearance="@style/StreamUiTextAppearance.Footnote"
+            android:layout_marginEnd="@dimen/padding_small"
+            android:maxLines="1"
+            android:ellipsize="end"
+            app:layout_constraintBottom_toBottomOf="@+id/iv_channel_list_thumb"
+            app:layout_constraintEnd_toStartOf="@+id/iv_channel_list_car"
+            app:layout_constraintStart_toStartOf="@+id/tv_channel_list_name"
+            app:layout_constraintTop_toBottomOf="@id/tv_channel_list_name"
+            app:layout_constraintVertical_chainStyle="spread_inside"
+            tools:text="안녕" />
+
+        <com.google.android.material.imageview.ShapeableImageView
+            android:id="@+id/iv_channel_list_car"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:layout_marginEnd="@dimen/padding_medium"
+            android:scaleType="centerCrop"
+            app:image_uri="@{carImage}"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:shapeAppearance="@style/ShapeAppearanceOverlay.App.CornerSize20Percent"
+            tools:src="@tools:sample/avatars" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -133,4 +133,6 @@
     <string name="chatting_toolbar">채팅</string>
     <string name="mypage_re_register">다시 등록하기</string>
     <string name="mypage_no_license">등록된 면허가 없습니다.</string>
+
+    <string name="permission_post_notification_denied">이 일을 기억할 것입니다.</string>
 </resources>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -134,5 +134,6 @@
     <string name="mypage_re_register">다시 등록하기</string>
     <string name="mypage_no_license">등록된 면허가 없습니다.</string>
 
+    <string name="chatting_provider_name">ucmc</string>
     <string name="permission_post_notification_denied">이 일을 기억할 것입니다.</string>
 </resources>


### PR DESCRIPTION
## 개요
- 채팅 노티피케이션 연결, 채팅 목록 드자인

## 작업사항
- 채팅 메세지를 보내면 상대방에게 노티가 갑니다.
  - 노티를 클릭하면 해당 채팅방으로 이동합니다.
- 채팅 목록에 문의 중인 자동차 썸네일이 표시됩니다.
  - 뭔 차에 대해 얘기 중인지 더욱 직관적으로 파악할 수 있겠지요
- POST NOTIFICATION 권한 요청 추가

## 변경된 부분
- NotificationService
  - 해집어 놨는데 추가된 코드는 몇 줄 없기 때문에 어렵지 않게 수정할 수 있읍니다.
- LicenseDataSource
  - ktlint 포맷팅
- CarDetailViewModel
  - 채팅방 생성 동작을 동기적으로 변경
- LoginActivity
  - 알림 권한 요청 부분 추가
- 스트링 리쏘쓰 추가

## 실행 화면 
### 채팅 목록
![채팅목록자동차](https://user-images.githubusercontent.com/90435036/204797228-d24dca27-fb44-48d9-b83b-6749228bea0a.jpg)

### 노티피케이션 전송
![채팅노티](https://user-images.githubusercontent.com/90435036/204797757-4812dd4f-05e2-454a-bd52-1fe981814325.gif)

## 특이사항
- 채팅방에 있어도 알림이 와요
  - 쿨하지 않기 때문에 내일 고치겠습니다.
