### PR TITLE
Feature:#137 알림 목록 상태 표시, 마지막 값 Erro 발생 fix

### DIFF
--- a/data/src/main/java/com/gta/data/model/Car.kt
+++ b/data/src/main/java/com/gta/data/model/Car.kt
@@ -14,10 +14,10 @@ data class Car(
     val pinkSlip: PinkSlip = PinkSlip(),
     val images: List<String> = emptyList(),
     val price: Int = 10000,
-    val location: String = "동훈이 집",
+    val location: String = "정보 없음",
     val coordinate: Coordinate = Coordinate(),
     val rentState: String = RentState.UNAVAILABLE.string,
-    val comment: String = "차였어요",
+    val comment: String = "정보 없음",
     val availableDate: AvailableDate = AvailableDate(),
     val ownerId: String = "정보 없음"
 )

--- a/data/src/main/java/com/gta/data/repository/NotificationRepositoryImpl.kt
+++ b/data/src/main/java/com/gta/data/repository/NotificationRepositoryImpl.kt
@@ -42,7 +42,7 @@ class NotificationRepositoryImpl @Inject constructor(
     suspend fun getNotificationInfoDetailItem(notifyInfo: NotificationInfo): NotificationInfo {
         val reservation = reservationDataSource.getReservation(notifyInfo.reservationId).first()
         val from = notifyInfo.fromId
-        val car = reservation?.carId ?: "-"
+        val car = reservation?.carId ?: "정보 없음"
 
         withContext(Dispatchers.IO) {
             launch {

--- a/data/src/main/java/com/gta/data/source/NotificationPagingSource.kt
+++ b/data/src/main/java/com/gta/data/source/NotificationPagingSource.kt
@@ -19,8 +19,14 @@ class NotificationPagingSource(
     override suspend fun load(params: LoadParams<QuerySnapshot>): LoadResult<QuerySnapshot, NotificationInfo> {
         return try {
             val currentPage = params.key ?: dataSource.getNotificationInfoCurrentItem(userId)
-            val lastDocumentSnapshot = currentPage.documents[currentPage.size() - 1]
-            val nextPage = dataSource.getNotificationInfoNextItem(userId, lastDocumentSnapshot)
+
+            val nextPage: QuerySnapshot? =
+                if (currentPage.size() > 0) {
+                    val lastDocumentSnapshot = currentPage.documents[currentPage.size() - 1]
+                    dataSource.getNotificationInfoNextItem(userId, lastDocumentSnapshot)
+                } else {
+                    null
+                }
 
             LoadResult.Page(
                 data = currentPage.map {

--- a/domain/src/main/java/com/gta/domain/model/Coordinate.kt
+++ b/domain/src/main/java/com/gta/domain/model/Coordinate.kt
@@ -1,6 +1,6 @@
 package com.gta.domain.model
 
 data class Coordinate(
-    val latitude: Double = 0.0,
-    val longitude: Double = 0.0
+    val latitude: Double = 37.3588798,
+    val longitude: Double = 127.1051933
 ) : java.io.Serializable

--- a/domain/src/main/java/com/gta/domain/usecase/cardetail/SetStateAtCarDetailUseCase.kt
+++ b/domain/src/main/java/com/gta/domain/usecase/cardetail/SetStateAtCarDetailUseCase.kt
@@ -1,8 +1,0 @@
-package com.gta.domain.usecase.cardetail
-
-import com.gta.domain.repository.CarRepository
-import javax.inject.Inject
-
-class SetStateAtCarDetailUseCase @Inject constructor(
-    private val carRepository: CarRepository
-)

--- a/presentation/src/main/java/com/gta/presentation/ui/notification/NotificationListFragment.kt
+++ b/presentation/src/main/java/com/gta/presentation/ui/notification/NotificationListFragment.kt
@@ -34,23 +34,7 @@ class NotificationListFragment : BaseFragment<FragmentNotificationListBinding>(
             setItemClickListener(object : NotificationListAdapter.OnItemClickListener {
                 override fun onClick(type: NotificationType, reservation: String) {
                     when (type) {
-                        NotificationType.REQUEST_RESERVATION -> {
-                            findNavController().navigate(
-                                NotificationListFragmentDirections
-                                    .actionNotificationListFragmentToReservationCheckFragment(
-                                        reservation
-                                    )
-                            )
-                        }
-                        NotificationType.ACCEPT_RESERVATION -> {
-                            findNavController().navigate(
-                                NotificationListFragmentDirections
-                                    .actionNotificationListFragmentToReservationCheckFragment(
-                                        reservation
-                                    )
-                            )
-                        }
-                        NotificationType.DECLINE_RESERVATION -> {
+                        NotificationType.REQUEST_RESERVATION, NotificationType.ACCEPT_RESERVATION, NotificationType.DECLINE_RESERVATION -> {
                             findNavController().navigate(
                                 NotificationListFragmentDirections
                                     .actionNotificationListFragmentToReservationCheckFragment(

--- a/presentation/src/main/java/com/gta/presentation/ui/notification/NotificationListFragment.kt
+++ b/presentation/src/main/java/com/gta/presentation/ui/notification/NotificationListFragment.kt
@@ -22,7 +22,7 @@ class NotificationListFragment : BaseFragment<FragmentNotificationListBinding>(
     R.layout.fragment_notification_list
 ) {
 
-    private val viewModel: NotificationViewModel by viewModels()
+    private val viewModel: NotificationListViewModel by viewModels()
     private val adapter by lazy { NotificationListAdapter() }
     override fun onCreateView(
         inflater: LayoutInflater,

--- a/presentation/src/main/java/com/gta/presentation/ui/notification/NotificationListFragment.kt
+++ b/presentation/src/main/java/com/gta/presentation/ui/notification/NotificationListFragment.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.fragment.findNavController
+import androidx.paging.LoadState
 import com.gta.domain.model.NotificationType
 import com.gta.presentation.R
 import com.gta.presentation.databinding.FragmentNotificationListBinding
@@ -59,6 +60,26 @@ class NotificationListFragment : BaseFragment<FragmentNotificationListBinding>(
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        adapter.addLoadStateListener {
+            binding.rvNotification.visibility = View.VISIBLE
+            binding.pgLoading.visibility = View.GONE
+
+            when (it.source.refresh) {
+                is LoadState.Loading -> {
+                    binding.pgLoading.visibility = View.VISIBLE
+                }
+                is LoadState.NotLoading -> {
+                    if (it.append.endOfPaginationReached && adapter.itemCount < 1) {
+                        binding.rvNotification.visibility = View.GONE
+                    }
+                }
+                is LoadState.Error -> {
+                    sendSnackBar(resources.getString(R.string.exception_load_data))
+                }
+                else -> {}
+            }
+        }
 
         lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {

--- a/presentation/src/main/java/com/gta/presentation/ui/notification/NotificationListViewModel.kt
+++ b/presentation/src/main/java/com/gta/presentation/ui/notification/NotificationListViewModel.kt
@@ -15,7 +15,7 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class NotificationViewModel @Inject constructor(
+class NotificationListViewModel @Inject constructor(
     getNotificationInfo: GetNotificationsInfoUseCase
 ) : ViewModel() {
 

--- a/presentation/src/main/res/layout/fragment_notification_list.xml
+++ b/presentation/src/main/res/layout/fragment_notification_list.xml
@@ -1,18 +1,38 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     tools:context=".ui.notification.NotificationListFragment">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
+        <TextView
+            android:id="@+id/tv_empty_case"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:gravity="center"
+            android:text="@string/notification_list_no_list"
+            android:visibility="gone" />
+
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/rv_notification"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"/>
+            android:background="?android:attr/colorBackground"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
+
+        <com.google.android.material.progressindicator.CircularProgressIndicator
+            android:id="@+id/pg_loading"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:indeterminate="true"
+            android:visibility="gone"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/presentation/src/main/res/layout/fragment_notification_list.xml
+++ b/presentation/src/main/res/layout/fragment_notification_list.xml
@@ -13,8 +13,7 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:gravity="center"
-            android:text="@string/notification_list_no_list"
-            android:visibility="gone" />
+            android:text="@string/notification_list_no_list" />
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/rv_notification"

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -58,6 +58,8 @@
     <string name="car_detail_year">%d년식</string>
     <string name="car_detail_licensePlate">번호판 : %s</string>
 
+    <string name="notification_list_no_list">해당 내용이 없습니다.</string>
+
     <string name="search_hint">검색어를 입력하세요.</string>
     <string name="filter_car_type">차종</string>
     <string name="filter_day">날짜</string>


### PR DESCRIPTION
## 개요
- 알림 목록의 로딩, 데이터 없음, 에러 상태를 표시
- 마지막 값을 가져올 때 Erro 발생하는 버그 FIX

## 작업사항
- 마자막 값 접근 시 Index -1 접근 막음
- 로딩, 데이터 없음, 에러발생 경우 UI 피드백

## 변경된 부분
- String 리소스 추가
- 사용하지 않는 usecase 삭제 -> founction 없을 경우 대바한 유즈케이스로 완전 쓸모없음(구현도 안되어있었음)

## 실행 화면

https://user-images.githubusercontent.com/59998983/206196951-6334b4b1-d93b-49ff-80b0-518d21f8d265.mp4

https://user-images.githubusercontent.com/59998983/206197005-3425f01f-26de-4376-8af2-935ad8b29c65.mp4


https://user-images.githubusercontent.com/59998983/206197021-4c0b4cf6-11a8-46e2-8529-482c8aa3a583.mp4




## 특이사항
- 알림에서 표시해주는 정보를 차번호판에서 차 이름으로 바꿀려고 했는데 그러면 사용자가 차번호판을 볼수있는 경우가 아무곳도 없더라구요..!
- 그 시간 최신순으로 하고 싶었는데 그럴려면 정렬을 해야하는데.. 그럴려면 그 필드에 시간 값 필드가 존재해야했더라고요.. 호호. 내일 말해봅시다
