### PR TITLE
Fix: 예약 확인 화면 버그 수정

### DIFF
--- a/presentation/src/main/java/com/gta/presentation/ui/reservation/check/ReservationCheckFragment.kt
+++ b/presentation/src/main/java/com/gta/presentation/ui/reservation/check/ReservationCheckFragment.kt
@@ -12,6 +12,7 @@ import com.gta.domain.model.UCMCResult
 import com.gta.presentation.R
 import com.gta.presentation.databinding.FragmentReservationCheckBinding
 import com.gta.presentation.ui.base.BaseFragment
+import com.gta.presentation.util.FirebaseUtil
 import com.gta.presentation.util.repeatOnStarted
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
@@ -85,7 +86,7 @@ class ReservationCheckFragment :
                             else -> null
                         }?.isChecked = true
 
-                        if (result.data.state == ReservationState.PENDING.state) {
+                        if (result.data.state == ReservationState.PENDING.state && result.data.ownerId == FirebaseUtil.uid) {
                             anchorView = binding.btnReservationAccept
                             View.VISIBLE
                         } else {

--- a/presentation/src/main/res/layout/fragment_reservation.xml
+++ b/presentation/src/main/res/layout/fragment_reservation.xml
@@ -33,7 +33,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:orientation="vertical"
-                    app:layout_constraintGuide_end="395dp" />
+                    app:layout_constraintGuide_begin="@dimen/padding_medium" />
 
                 <androidx.constraintlayout.widget.Guideline
                     android:id="@+id/gl_reservation_end"


### PR DESCRIPTION
## 개요
예약 확인 화면에서 차주가 대여 수락 전 대여자가 니차거래목록에서 예약 정보 확인 시 수락/거절 이 가능했음

## 작업사항
- 차주이면서 보류중일때만 수락/거절 가능

## 변경된 부분
- ReservationCheckFragment

## 실행 화면


## 특이사항
- 추가로 예약 화면 왼쪽 마진이 이상해서 수정했어요
