### PR TITLE
Fix: #161 예약 수락/거절 시 중복 생성 버그 수정

### DIFF
--- a/domain/src/main/java/com/gta/domain/usecase/reservation/FinishReservationUseCase.kt
+++ b/domain/src/main/java/com/gta/domain/usecase/reservation/FinishReservationUseCase.kt
@@ -3,31 +3,31 @@ package com.gta.domain.usecase.reservation
 import com.gta.domain.model.Notification
 import com.gta.domain.model.NotificationType
 import com.gta.domain.model.Reservation
+import com.gta.domain.model.ReservationState
 import com.gta.domain.repository.ReservationRepository
 import com.gta.domain.usecase.SendNotificationUseCase
-import kotlinx.coroutines.flow.first
 import javax.inject.Inject
 
 class FinishReservationUseCase @Inject constructor(
-    private val repository: ReservationRepository,
+    private val reservationRepository: ReservationRepository,
     private val notificationUseCase: SendNotificationUseCase
 ) {
     suspend operator fun invoke(
         accepted: Boolean,
         reservation: Reservation,
-        ownerId: String
+        reservationId: String
     ): Boolean {
-        val reservationId = repository.createReservation(reservation).first()
-        val notificationResult = notificationUseCase(
-            Notification(
-                type = if (accepted) NotificationType.ACCEPT_RESERVATION.title else NotificationType.DECLINE_RESERVATION.title,
-                message = if (accepted) NotificationType.ACCEPT_RESERVATION.msg else NotificationType.DECLINE_RESERVATION.msg,
-                reservationId = reservationId,
-                fromId = ownerId,
-                timestamp = System.currentTimeMillis()
-            ),
-            reservation.lenderId
+        val notification = Notification(
+            type = if (accepted) NotificationType.ACCEPT_RESERVATION.title else NotificationType.DECLINE_RESERVATION.title,
+            message = if (accepted) NotificationType.ACCEPT_RESERVATION.msg else NotificationType.DECLINE_RESERVATION.msg,
+            reservationId = reservationId,
+            fromId = reservation.ownerId,
+            timestamp = System.currentTimeMillis()
         )
-        return reservationId.isNotEmpty() && notificationResult
+
+        return reservationId.isNotEmpty() && reservationRepository.updateReservationState(
+            reservationId,
+            if (accepted) ReservationState.ACCEPT else ReservationState.CANCEL
+        ) && notificationUseCase(notification, reservation.lenderId)
     }
 }

--- a/presentation/src/main/java/com/gta/presentation/ui/reservation/check/ReservationCheckViewModel.kt
+++ b/presentation/src/main/java/com/gta/presentation/ui/reservation/check/ReservationCheckViewModel.kt
@@ -126,7 +126,6 @@ class ReservationCheckViewModel @Inject constructor(
 
     fun finishReservation(accepted: Boolean) {
         val reservation = reservation.value
-        val ownerId = reservation.ownerId
         val state = if (accepted) ReservationState.ACCEPT else ReservationState.CANCEL
 
         viewModelScope.launch {
@@ -134,7 +133,7 @@ class ReservationCheckViewModel @Inject constructor(
                 finishReservationUseCase(
                     accepted,
                     reservation.copy(state = state.state),
-                    ownerId
+                    reservationId
                 )
             )
         }


### PR DESCRIPTION
## 개요
예약 수락 또는 거절 시 아이디가 달라 예약 내용이 중복으로 생기는 버그

## 작업사항
- 해당 예약의 상태를 바꾸도록 변경
