### PR TITLE
Feature: #160 마커 색상 변경 로직 수정 & 마커 리스트 저장 로직 변경

### DIFF
--- a/presentation/src/main/java/com/gta/presentation/ui/map/MapViewModel.kt
+++ b/presentation/src/main/java/com/gta/presentation/ui/map/MapViewModel.kt
@@ -12,6 +12,7 @@ import com.gta.domain.usecase.map.GetSearchAddressUseCase
 import com.gta.presentation.util.EventFlow
 import com.gta.presentation.util.MutableEventFlow
 import com.gta.presentation.util.asEventFlow
+import com.naver.maps.map.overlay.Marker
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CompletableJob
 import kotlinx.coroutines.Dispatchers
@@ -46,7 +47,7 @@ class MapViewModel @Inject constructor(
         extraBufferCapacity = 1,
         onBufferOverflow = BufferOverflow.DROP_OLDEST
     )
-    val carsRequest: SharedFlow<Pair<Coordinate, Coordinate>> get() = _carsRequest
+    private val carsRequest: SharedFlow<Pair<Coordinate, Coordinate>> get() = _carsRequest
 
     private var _carsResponse = MutableEventFlow<UCMCResult<List<SimpleCar>>>()
     val carsResponse: EventFlow<UCMCResult<List<SimpleCar>>> get() = _carsResponse.asEventFlow()
@@ -62,6 +63,9 @@ class MapViewModel @Inject constructor(
 
     private var _selectCar = MutableStateFlow(SimpleCar())
     val selectCar: StateFlow<SimpleCar> get() = _selectCar
+
+    var selectedMarker: Marker? = null
+        private set
 
     private lateinit var collectJob: CompletableJob
 
@@ -107,6 +111,10 @@ class MapViewModel @Inject constructor(
         viewModelScope.launch {
             _searchRequest.emit(query)
         }
+    }
+
+    fun clickMarker(marker: Marker?) {
+        selectedMarker = marker
     }
 
     private val _location = MutableSharedFlow<String?>()


### PR DESCRIPTION
## 개요
지도 디테일 수정했습니다

## 작업사항
- 마커 색상 변경 로직 수정
  - 뷰모델에서 선택된 마커 저장
  - 마커가 겹칠 시 선택된 마커가 가장 위로 올라감
- 마커 리스트 저장 로직 변경
  - 기존에 가지고 있던 마커라면 유지, 새로운 마커라면 추가로 저장, 필요 없는 마커라면 삭제

## 실행 화면
https://user-images.githubusercontent.com/62137001/206859761-56b0b776-be2f-4710-863d-998249e3737f.mov
